### PR TITLE
Improve void and union types

### DIFF
--- a/lib/xdr/void.ex
+++ b/lib/xdr/void.ex
@@ -52,6 +52,7 @@ defmodule XDR.Void do
   """
   @spec decode_xdr(binary, any) :: {:ok, {nil, binary}} | {:error, :not_void}
   def decode_xdr(<<>>, _), do: {:ok, {nil, ""}}
+  def decode_xdr(<<rest::binary>>, _), do: {:ok, {nil, rest}}
   def decode_xdr(_, _), do: {:error, :not_void}
   @impl XDR.Declaration
   @doc """
@@ -63,5 +64,6 @@ defmodule XDR.Void do
   @spec decode_xdr!(binary, any) :: {nil, binary}
   def decode_xdr!(bytes, opts \\ nil)
   def decode_xdr!(<<>>, _), do: {nil, ""}
+  def decode_xdr!(<<rest::binary>>, _), do: {nil, rest}
   def decode_xdr!(_, _), do: raise(Void, :not_void)
 end

--- a/test/xdr/union_test.exs
+++ b/test/xdr/union_test.exs
@@ -114,6 +114,56 @@ defmodule XDR.UnionTest do
     end
   end
 
+  describe "Encoding discriminated union with types" do
+    test "when receives an invalid identifier" do
+      {status, reason} =
+        "SCP_ST_EXTERNALIZE"
+        |> UnionSCPStatementWithTypes.new()
+        |> UnionSCPStatementWithTypes.encode_xdr()
+
+      assert status == :error
+      assert reason == :not_atom
+    end
+
+    test "encode_xdr! when receives an invalid identifier" do
+      assert_raise UnionErr, fn ->
+        "SCP_ST_EXTERNALIZE"
+        |> UnionSCPStatementWithTypes.new()
+        |> UnionSCPStatementWithTypes.encode_xdr!()
+      end
+    end
+
+    test "encode_xdr Enum example" do
+      {status, result} =
+        UnionSCPStatementWithTypes.new(:SCP_ST_PREPARE, 60)
+        |> UnionSCPStatementWithTypes.encode_xdr()
+
+      assert status == :ok
+      assert result == <<0, 0, 0, 0, 0, 0, 0, 60>>
+    end
+
+    test "encode_xdr! Enum example" do
+      result =
+        UnionSCPStatementWithTypes.new(:SCP_ST_PREPARE, 60)
+        |> UnionSCPStatementWithTypes.encode_xdr!()
+
+      assert result == <<0, 0, 0, 0, 0, 0, 0, 60>>
+    end
+
+    test "Uint example" do
+      {status, result} = UnionNumberWithTypes.new(3, 3.46) |> UnionNumberWithTypes.encode_xdr()
+
+      assert status == :ok
+      assert result == <<0, 0, 0, 3, 64, 93, 112, 164>>
+    end
+
+    test "encode_xdr! Uint example" do
+      result = UnionNumberWithTypes.new(3, 3.46) |> UnionNumberWithTypes.encode_xdr!()
+
+      assert result == <<0, 0, 0, 3, 64, 93, 112, 164>>
+    end
+  end
+
   describe "Decoding Discriminated Union" do
     test "when receives an invalid identifier" do
       arms = [
@@ -215,12 +265,65 @@ defmodule XDR.UnionTest do
       assert_raise UnionErr, fn -> Union.decode_xdr!([0, 0, 0, 0, 0, 0, 0, 0], enum) end
     end
   end
+
+  describe "Decoding Discriminated Union with types" do
+    test "when receives an invalid identifier" do
+      {status, reason} = UnionSCPStatementWithTypes.decode_xdr([0, 0, 0, 0, 0, 0, 0, 0])
+
+      assert status == :error
+      assert reason == :not_binary
+    end
+
+    test "when receives an invalid declarations" do
+      {status, reason} =
+        UnionSCPStatementWithTypes.decode_xdr(<<0, 0, 0, 0, 0, 0, 0, 0>>, %{
+          discriminant: %{declarations: nil},
+          arms: []
+        })
+
+      assert status == :error
+      assert reason == :not_list
+    end
+
+    test "when receives an invalid binary" do
+      {status, reason} = UnionNumberWithTypes.decode_xdr([0, 0, 0, 3, 64, 93, 112, 164])
+
+      assert status == :error
+      assert reason == :not_binary
+    end
+
+    test "Enum example" do
+      {status, result} = UnionSCPStatementWithTypes.decode_xdr(<<0, 0, 0, 0, 0, 0, 0, 60>>)
+
+      assert status == :ok
+      assert result == {{:SCP_ST_PREPARE, %XDR.Int{datum: 60}}, ""}
+    end
+
+    test "decode_xdr! with Enum example" do
+      result = UnionSCPStatementWithTypes.decode_xdr!(<<0, 0, 0, 0, 0, 0, 0, 60>>)
+
+      assert result == {{:SCP_ST_PREPARE, %XDR.Int{datum: 60}}, ""}
+    end
+
+    test "Uint example" do
+      {status, result} = UnionNumberWithTypes.decode_xdr(<<0, 0, 0, 3, 64, 93, 112, 164>>)
+
+      assert status == :ok
+      assert result == {{3, %XDR.Float{float: 3.4600000381469727}}, ""}
+    end
+
+    test "decode_xdr! with Uint Example" do
+      result = UnionNumberWithTypes.decode_xdr!(<<0, 0, 0, 3, 64, 93, 112, 164>>)
+
+      assert result == {{3, %XDR.Float{float: 3.4600000381469727}}, ""}
+    end
+  end
 end
 
 defmodule UnionSCPStatementType do
   @behaviour XDR.Declaration
 
-  defstruct discriminant: XDR.Enum, arms: nil, struct: nil
+  defstruct discriminant: XDR.Enum, arms: nil, struct: nil, value: nil
 
   @arms [
     SCP_ST_PREPARE: XDR.Int.new(60),
@@ -255,7 +358,7 @@ end
 defmodule UnionNumber do
   @behaviour XDR.Declaration
 
-  defstruct discriminant: XDR.UInt, arms: nil, struct: nil
+  defstruct discriminant: XDR.UInt, arms: nil, struct: nil, value: nil
 
   @arms %{
     0 => XDR.Int.new(60),
@@ -305,4 +408,62 @@ defmodule SCPStatementType do
   defdelegate decode_xdr(bytes, struct), to: XDR.Enum
   @impl XDR.Declaration
   defdelegate decode_xdr!(bytes, struct), to: XDR.Enum
+end
+
+defmodule UnionNumberWithTypes do
+  @arms %{
+    0 => XDR.Int,
+    1 => XDR.String,
+    2 => XDR.Bool,
+    3 => XDR.Float
+  }
+
+  def new(identifier, value \\ nil) do
+    identifier |> XDR.UInt.new() |> XDR.Union.new(@arms, value)
+  end
+
+  @behaviour XDR.Declaration
+
+  @impl XDR.Declaration
+  def encode_xdr(union), do: XDR.Union.encode_xdr(union)
+
+  @impl XDR.Declaration
+  def encode_xdr!(union), do: XDR.Union.encode_xdr!(union)
+
+  @impl XDR.Declaration
+  def decode_xdr(bytes, union \\ new(nil))
+  def decode_xdr(bytes, union), do: XDR.Union.decode_xdr(bytes, union)
+
+  @impl XDR.Declaration
+  def decode_xdr!(bytes, union \\ new(nil))
+  def decode_xdr!(bytes, union), do: XDR.Union.decode_xdr!(bytes, union)
+end
+
+defmodule UnionSCPStatementWithTypes do
+  @arms [
+    SCP_ST_PREPARE: XDR.Int,
+    SCP_ST_CONFIRM: XDR.String,
+    SCP_ST_EXTERNALIZE: XDR.Bool,
+    SCP_ST_NOMINATE: XDR.Float
+  ]
+
+  def new(identifier, value \\ nil) do
+    identifier |> SCPStatementType.new() |> XDR.Union.new(@arms, value)
+  end
+
+  @behaviour XDR.Declaration
+
+  @impl XDR.Declaration
+  def encode_xdr(union), do: XDR.Union.encode_xdr(union)
+
+  @impl XDR.Declaration
+  def encode_xdr!(union), do: XDR.Union.encode_xdr!(union)
+
+  @impl XDR.Declaration
+  def decode_xdr(bytes, union \\ new(nil))
+  def decode_xdr(bytes, union), do: XDR.Union.decode_xdr(bytes, union)
+
+  @impl XDR.Declaration
+  def decode_xdr!(bytes, union \\ new(nil))
+  def decode_xdr!(bytes, union), do: XDR.Union.decode_xdr!(bytes, union)
 end

--- a/test/xdr/void_test.exs
+++ b/test/xdr/void_test.exs
@@ -43,7 +43,7 @@ defmodule XDR.VoidTest do
     end
   end
 
-  describe "Decoding binary to integer" do
+  describe "Decoding binary to void" do
     test "when is not binary value" do
       {status, reason} = Void.decode_xdr(5860, XDR.Void)
 
@@ -51,11 +51,11 @@ defmodule XDR.VoidTest do
       assert reason == :not_void
     end
 
-    test "with invalid binary" do
-      {status, reason} = Void.decode_xdr(<<0>>, XDR.Void)
+    test "with binary rest" do
+      {status, reason} = Void.decode_xdr(<<116, 101, 115, 116>>, XDR.Void)
 
-      assert status == :error
-      assert reason == :not_void
+      assert status == :ok
+      assert reason == {nil, <<116, 101, 115, 116>>}
     end
 
     test "when is a valid binary" do
@@ -71,12 +71,18 @@ defmodule XDR.VoidTest do
       assert reason === {nil, ""}
     end
 
+    test "decode_xdr! with rest" do
+      reason = Void.decode_xdr!(<<116, 101, 115, 116>>, XDR.Void)
+
+      assert reason === {nil, <<116, 101, 115, 116>>}
+    end
+
     test "decode_xdr! with invalid data" do
-      assert_raise VoidErr, fn -> Void.decode_xdr!(<<0>>, XDR.Void) end
+      assert_raise VoidErr, fn -> Void.decode_xdr!(12_345, XDR.Void) end
     end
 
     test "decode_xdr! with one parameter" do
-      assert_raise VoidErr, fn -> Void.decode_xdr!(<<0>>) end
+      assert_raise VoidErr, fn -> Void.decode_xdr!(nil) end
     end
   end
 end


### PR DESCRIPTION
## Improve the types: Void and Discriminated Union

- **Void**
    - Allow to decode a XDR binary to Void and leave a binary rest to continue decoding.

- **Discriminated Union**
    - Allow to declare a XDR discriminated union with a keyword list of modules as arms .

These improvements are needed to continue with our Stellar SDK library.


