### PR TITLE
Improve discriminated union with default arm

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Process XDR types based on the [RFC4506](https://www.ietf.org/rfc/rfc4506.txt). 
 ```elixir
 def deps do
   [
-    {:elixir_xdr, "~> 0.1.0"}
+    {:elixir_xdr, "~> 0.1.3"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -375,13 +375,13 @@ A discriminated union is a type composed of a discriminant followed by a type se
 
 The type of discriminant is either `XDR.Int`, `XDR.UInt`, or an `XDR.Enum` type. 
 
-The `arms` can be a keyword list or a map and the value of each arm can be either a struct or a module of any XDR type.
+The `arms` can be a keyword list or a map and the value of each arm can be either a struct or a module of any XDR type. You can define a default arm using `:default` as key (The default arm is optional).
 
 Encoding:
 
 ```elixir
 iex(1)> enum = %XDR.Enum{declarations: [case_1: 1, case_2: 2, case_3: 3], identifier: :case_1}
-iex(2)> arms = [case_1: %XDR.Int{datum: 123}, case_2: %XDR.Int{datum: 2}, case_3: XDR.Float]
+iex(2)> arms = [case_1: %XDR.Int{datum: 123}, case_2: %XDR.Int{datum: 2}, case_3: XDR.Float, default: XDR.String]
 iex(3)> enum |> XDR.Union.new(arms) |> XDR.Union.encode_xdr()
 {:ok, <<0, 0, 0, 1, 0, 0, 0, 123>>}
 ```
@@ -390,13 +390,13 @@ Decoding:
 
 ```elixir
 iex(1)> enum = %XDR.Enum{declarations: [case_1: 1, case_2: 2, case_3: 3]}
-iex(2)> arms = [case_1: %XDR.Int{datum: 123}, case_2: %XDR.Int{datum: 2}, case_3: XDR.Float]
+iex(2)> arms = [case_1: %XDR.Int{datum: 123}, case_2: %XDR.Int{datum: 2}, case_3: XDR.Float, default: XDR.String]
 iex(3)> union = XDR.Union.new(enum, arms) # Define the union specification to decode.
 iex(4)> XDR.Union.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 123>>, union)
 {:ok, {{:case_1, %XDR.Int{datum: 123}}, ""}} 
 ```
 
-An example is available here: [Union Example](https://github.com/kommitters/elixir_xdr/wiki/Union-example)
+Some usage and implementation examples are available here: [Union Example](https://github.com/kommitters/elixir_xdr/wiki/Union-example)
 
 ### Void
 

--- a/guides/examples/discriminated_union.md
+++ b/guides/examples/discriminated_union.md
@@ -6,21 +6,11 @@ Represents an xdr discriminated union.
 
 The type of discriminant is either `XDR.Int`, `XDR.UInt`, or an `XDR.Enum` type. 
 
-The `arms` can be a keyword list or a map and the value of each arm can be either a struct or a module of any XDR type.
-
-**For Enumeration unions:**
-```elixir
-arms = [case_1: %XDR.Int{datum: 1}, case_2: %XDR.Int{datum: 2}, case_3: XDR.Int]
-```
-
-**For numeric unions:**
-```elixir
-arms = %{1 => %XDR.Int{datum: 1}, 2 => %XDR.Int{datum: 2}, 3 => XDR.Int}
-```
+The `arms` can be a keyword list or a map and the value of each arm can be either a struct or a module of any XDR type. You can define a default arm using `:default` as key (The default arm is optional).
 
 ### Custom Union
 
-You can define your own custom union:
+You can define your own custom implementation:
 
 ```elixir
 defmodule CustomUnion do
@@ -33,9 +23,9 @@ defmodule CustomUnion do
 
   @type t :: Union.t()
 
-  @spec new(union :: any(), union_code :: atom()) :: t
-  def new(union, union_code) do
-    union_code |> CustomEnum.new() |> Union.new(@arms, union)
+  @spec new(value :: any(), union_code :: atom()) :: t
+  def new(value, union_code) do
+    union_code |> CustomEnum.new() |> Union.new(@arms, value)
   end
 
   @spec spec() :: t
@@ -48,25 +38,56 @@ defmodule CustomUnion do
 end
 ```
 
+```elixir
+# Encode
+value_depending_on_the_type |> CustomUnion.new(:type_1) |> CustomUnion.encode_xdr()
+```
+
+```elixir
+# Decode
+CustomUnion.decode_xdr(<<1, 2, 3, 4, 5, 6, 7, 8>>)
+```
+
 ## Usage
 
+### arms definition
+
+**For union with enumeration as discriminant:**
+```elixir
+iex(1)> arms = [case_1: %XDR.Int{datum: 1}, case_2: %XDR.Int{datum: 2}, case_3: XDR.Int, default: XDR.Float]
+```
+**For union with integer as discriminant:**
+```elixir
+iex(1)> arms = %{1 => %XDR.Int{datum: 1}, 2 => %XDR.Int{datum: 2}, 3 => XDR.Int, default: XDR.Float}
+```
+
 ### Encoding
-**For Enumeration unions:**
-```elixir 
-iex(1)> XDR.Enum.new([case_1: 1, case_2: 2], :case_1)
-|> XDR.Union.new(arms)
-|> XDR.Union.encode_xdr()
+**For union with enumeration as discriminant:**
+```elixir
+# encode_xdr
+
+iex(1)> XDR.Enum.new([case_1: 1, case_2: 2], :case_1) |>
+...(1)> XDR.Union.new(arms) |>
+...(1)> XDR.Union.encode_xdr()
 {:ok, <<0, 0, 0, 1, 0, 0, 0, 1>>}
+
+# encode_xdr!
 
 # Using an XDR module to encode.
 # Note you must to pass the value to encode to the function `XDR.Union.new/3`.
-iex(1)> XDR.Enum.new([case_1: 1, case_2: 2, case_3: 3], :case_3)
-|> XDR.Union.new(arms, 100)
-|> XDR.Union.encode_xdr()
-{:ok, <<0, 0, 0, 3, 0, 0, 0, 100>>}
+iex(1)> XDR.Enum.new([case_1: 1, case_2: 2, case_3: 3], :case_3) |>
+...(1)> XDR.Union.new(arms, 100) |>
+...(1)> XDR.Union.encode_xdr!()
+<<0, 0, 0, 3, 0, 0, 0, 100>>
+
+# Encode a default arm.
+iex(1)> XDR.Enum.new([case_1: 1, case_2: 2, case_3: 3, case_10: 10], :case_10) |>
+...(1)> XDR.Union.new(arms, 12.3333) |>
+...(1)> XDR.Union.encode_xdr()
+{:ok, <<0, 0, 0, 10, 65, 69, 85, 50>>} 
 ```
 
-**For Numeric unions:**
+**For union with integer as discriminant:**
 ```elixir 
 iex(1)> XDR.Int.new(1) |> XDR.Union.new(arms) |> XDR.Union.encode_xdr()
 {:ok, <<0, 0, 0, 1, 0, 0, 0, 1>>}
@@ -77,20 +98,40 @@ iex(1)> XDR.UInt.new(3) |> XDR.Union.new(arms, 100) |> XDR.Union.encode_xdr!()
 
 ### Decoding
 
-**For Enumeration unions:**
-```elixir 
+**For union with enumeration as discriminant:**
+```elixir
+# decode_xdr
+
 iex(1)> enum = XDR.Enum.new([case_1: 1, case_2: 2], nil)
-iex(2)> XDR.Union.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 1>>, %{discriminant: enum, arms: arms})
+iex(2)> union_spec = XDR.Union.new(enum, arms) # Define the union specification to decode.
+iex(3)> XDR.Union.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 1>>, union_spec)
 {:ok, {{:case_1, %XDR.Int{datum: 1}}, <<>>}}
+
+# decode_xdr!
+
+iex(1)> enum = XDR.Enum.new([case_1: 1, case_2: 2], nil)
+iex(2)> union_spec = %{discriminant: enum, arms: arms} # Also you can pass a map as union specification.
+iex(3)> XDR.Union.decode_xdr!(<<0, 0, 0, 2, 0, 0, 0, 20>>, union_spec)
+{{:case_2, %XDR.Int{datum: 20}}, <<>>}
+
+# Decode a default arm.
+iex(1)> enum = XDR.Enum.new([case_1: 1, case_2: 2, case_3: 3, case_10: 10], :case_10)
+...(1)> union_spec = XDR.Union.new(enum, arms)
+...(1)> XDR.Union.decode_xdr(<<0, 0, 0, 10, 65, 69, 85, 50>>, union_spec)
+{:ok, {{:case_10, %XDR.Float{float: 12.33329963684082}}, ""}}
 ```
 
-**For Numeric unions:**
-```elixir 
+**For union with integer as discriminant:**
+```elixir
+# decode_xdr
 iex(1)> integer = XDR.Int.new(nil)
-iex(2)> XDR.Union.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 1>>, %{discriminant: integer, arms: arms})
+iex(2)> union_spec = XDR.Union.new(integer, arms)
+iex(3)> XDR.Union.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 1>>, union_spec)
 {:ok, {{1, %XDR.Int{datum: 1}}, <<>>}}
 
+#decode_xdr!
 iex(1)> integer = XDR.UInt.new(nil)
-iex(2)> XDR.Union.decode_xdr(<<0, 0, 0, 2, 0, 0, 0, 2>>, %{discriminant: integer, arms: arms})
-{{2, %XDR.Int{datum: 2}}, <<>>}
+iex(2)> union_spec = XDR.Union.new(integer, arms)
+iex(3)> XDR.Union.decode_xdr!(<<0, 0, 0, 2, 0, 0, 0, 7>>, union_spec)
+{{2, %XDR.Int{datum: 7}}, <<>>}
 ```

--- a/guides/examples/discriminated_union.md
+++ b/guides/examples/discriminated_union.md
@@ -1,18 +1,51 @@
 # Discriminated Union
 
- Represents union between an XDR value and the arms contained in the Union
+Represents an xdr discriminated union.
 
 ## Implementation
 
-To implement a Union type you must code the arms which contain the value to make the union.
+The type of discriminant is either `XDR.Int`, `XDR.UInt`, or an `XDR.Enum` type. 
+
+The `arms` can be a keyword list or a map and the value of each arm can be either a struct or a module of any XDR type.
 
 **For Enumeration unions:**
 ```elixir
-arms = [case_1: %XDR.Int{datum: 1}, case_2: %XDR.Int{datum: 2}]
+arms = [case_1: %XDR.Int{datum: 1}, case_2: %XDR.Int{datum: 2}, case_3: XDR.Int]
 ```
+
 **For numeric unions:**
 ```elixir
-arms = %{1 => %XDR.Int{datum: 1}, 2 => %XDR.Int{datum: 2}}
+arms = %{1 => %XDR.Int{datum: 1}, 2 => %XDR.Int{datum: 2}, 3 => XDR.Int}
+```
+
+### Custom Union
+
+You can define your own custom union:
+
+```elixir
+defmodule CustomUnion do
+
+  @arms [
+    Type_1: Type1,
+    Type_2: Type2,
+    default: Void
+  ]
+
+  @type t :: Union.t()
+
+  @spec new(union :: any(), union_code :: atom()) :: t
+  def new(union, union_code) do
+    union_code |> CustomEnum.new() |> Union.new(@arms, union)
+  end
+
+  @spec spec() :: t
+  defp spec(), do: CustomEnum.new(nil) |> Union.new(@arms)
+
+  defdelegate encode_xdr(union), to: Union
+  defdelegate encode_xdr!(union), to: Union
+  defdelegate decode_xdr(bytes, union \\ spec()), to: Union
+  defdelegate decode_xdr!(bytes, union \\ spec()), to: Union
+end
 ```
 
 ## Usage
@@ -20,34 +53,44 @@ arms = %{1 => %XDR.Int{datum: 1}, 2 => %XDR.Int{datum: 2}}
 ### Encoding
 **For Enumeration unions:**
 ```elixir 
-iex> XDR.Enum.new([case_1: 1, case_2: 2], :case_1)
+iex(1)> XDR.Enum.new([case_1: 1, case_2: 2], :case_1)
 |> XDR.Union.new(arms)
 |> XDR.Union.encode_xdr()
-
 {:ok, <<0, 0, 0, 1, 0, 0, 0, 1>>}
+
+# Using an XDR module to encode.
+# Note you must to pass the value to encode to the function `XDR.Union.new/3`.
+iex(1)> XDR.Enum.new([case_1: 1, case_2: 2, case_3: 3], :case_3)
+|> XDR.Union.new(arms, 100)
+|> XDR.Union.encode_xdr()
+{:ok, <<0, 0, 0, 3, 0, 0, 0, 100>>}
 ```
+
 **For Numeric unions:**
 ```elixir 
-XDR.Int.new(1) |> XDR.Union.new(arms) |> XDR.Union.encode_xdr()
+iex(1)> XDR.Int.new(1) |> XDR.Union.new(arms) |> XDR.Union.encode_xdr()
 {:ok, <<0, 0, 0, 1, 0, 0, 0, 1>>}
 
-XDR.UInt.new(2) |> XDR.Union.new(arms) |> XDR.Union.encode_xdr!()
-<<0, 0, 0, 2, 0, 0, 0, 2>>
+iex(1)> XDR.UInt.new(3) |> XDR.Union.new(arms, 100) |> XDR.Union.encode_xdr!()
+<<0, 0, 0, 3, 0, 0, 0, 100>> 
 ```
+
 ### Decoding
+
 **For Enumeration unions:**
 ```elixir 
-iex> enum = XDR.Enum.new([case_1: 1, case_2: 2], nil)
-iex> XDR.Union.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 1>>, %{discriminant: enum, arms: arms})
+iex(1)> enum = XDR.Enum.new([case_1: 1, case_2: 2], nil)
+iex(2)> XDR.Union.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 1>>, %{discriminant: enum, arms: arms})
 {:ok, {{:case_1, %XDR.Int{datum: 1}}, <<>>}}
 ```
+
 **For Numeric unions:**
 ```elixir 
-iex> integer = XDR.Int.new(nil)
-iex> XDR.Union.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 1>>, %{discriminant: integer, arms: arms})
+iex(1)> integer = XDR.Int.new(nil)
+iex(2)> XDR.Union.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 1>>, %{discriminant: integer, arms: arms})
 {:ok, {{1, %XDR.Int{datum: 1}}, <<>>}}
 
-iex> integer = XDR.UInt.new(nil)
-iex> XDR.Union.decode_xdr(<<0, 0, 0, 2, 0, 0, 0, 2>>, %{discriminant: integer, arms: arms})
+iex(1)> integer = XDR.UInt.new(nil)
+iex(2)> XDR.Union.decode_xdr(<<0, 0, 0, 2, 0, 0, 0, 2>>, %{discriminant: integer, arms: arms})
 {{2, %XDR.Int{datum: 2}}, <<>>}
 ```

--- a/guides/examples/void.md
+++ b/guides/examples/void.md
@@ -1,22 +1,31 @@
 # Void
 
- Represents the void types or nil in elixir case
+ Represents the XDR void type or nil in elixir case. Voids are useful for describing operations that take no data as input or no data as output.
 
 ## Usage
 
 ### Encoding
+
 ```elixir 
 iex> XDR.Void.new(nil) |> XDR.Void.encode_xdr()
 {:ok, <<>>}
 
-iex> XDR.Void.new(nil) |> XDR.Void.encode_xdr!()
+iex> XDR.Void.new() |> XDR.Void.encode_xdr!()
 <<>>
 ```
+
 ### Decoding
+
 ```elixir 
 iex> XDR.Void.decode_xdr(<<>>)
 {:ok, {nil, <<>>}}
 
 iex> XDR.Void.decode_xdr!(<<>>)
 {nil, <<>>}
+
+iex> XDR.Void.decode_xdr(<<72, 101, 108, 108, 111, 0>>)
+{:ok, {nil, <<72, 101, 108, 108, 111, 0>>}}
+
+iex> XDR.Void.decode_xdr!(<<72, 101, 108, 108, 111>>)
+{nil, <<72, 101, 108, 108, 111, 0>>}
 ```

--- a/lib/error/error.ex
+++ b/lib/error/error.ex
@@ -1,729 +1,566 @@
 defmodule XDR.Error do
   @moduledoc """
-  Module that is in charge of raise the errors resulted from encode or decode operations
+  This module contains the definitions of the errors resulted from XDR encode or decode operations.
   """
 
   defmodule Int do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.Int module
+    This module contains the definition of `XDR.Error.Int` exception that may be raised by the `XDR.Int` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.Int module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-
-      ### Example
-        def exception(:not_integer) do
-          ...
-        end
-
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.Int` exception with the message of the `error_type` passed.
     """
     def exception(:not_integer) do
-      msg = "The value which you try to encode is not an integer"
-      %XDR.Error.Int{message: msg}
+      new("The value which you try to encode is not an integer")
     end
 
     def exception(:not_binary) do
-      msg =
-        "The value which you try to decode must be a binary value, for example: <<0, 0, 0, 2>>"
-
-      %XDR.Error.Int{message: msg}
+      new("The value which you try to decode must be a binary value, for example: <<0, 0, 0, 2>>")
     end
 
     def exception(:exceed_upper_limit) do
-      msg =
+      new(
         "The integer which you try to encode exceed the upper limit of an integer, the value must be less than 2_147_483_647"
-
-      %XDR.Error.Int{message: msg}
+      )
     end
 
     def exception(:exceed_lower_limit) do
-      msg =
+      new(
         "The integer which you try to encode exceed the lower limit of an integer, the value must be more than -2_147_483_648"
-
-      %XDR.Error.Int{message: msg}
+      )
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.Int{message: msg}
   end
 
   defmodule UInt do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.UInt module
+    This module contains the definition of `XDR.Error.UInt` exception that may be raised by the `XDR.UInt` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.UInt module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-
-      ### Example
-        def exception(:not_list) do
-          ...
-        end
-
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.UInt` exception with the message of the `error_type` passed.
     """
     def exception(:not_integer) do
-      msg = "The value which you try to encode is not an integer"
-      %XDR.Error.UInt{message: msg}
+      new("The value which you try to encode is not an integer")
     end
 
     def exception(:not_binary) do
-      msg =
-        "The value which you try to decode must be a binary value, for example: <<0, 0, 0, 2>>"
-
-      %XDR.Error.UInt{message: msg}
+      new("The value which you try to decode must be a binary value, for example: <<0, 0, 0, 2>>")
     end
 
     def exception(:exceed_upper_limit) do
-      msg =
+      new(
         "The integer which you try to encode exceed the upper limit of an unsigned integer, the value must be less than 4_294_967_295"
-
-      %XDR.Error.UInt{message: msg}
+      )
     end
 
     def exception(:exceed_lower_limit) do
-      msg =
+      new(
         "The integer which you try to encode exceed the lower limit of an unsigned integer, the value must be more than 0"
-
-      %XDR.Error.UInt{message: msg}
+      )
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.UInt{message: msg}
   end
 
   defmodule Enum do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.Enum module
+    This module contains the definition of `XDR.Error.Enum` exception that may be raised by the `XDR.Enum` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.Enum module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-
-      ### Example
-        def exception(:not_list) do
-          ...
-        end
-
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.Enum` exception with the message of the `error_type` passed.
     """
     def exception(:not_list) do
-      msg = "The declaration inside the Enum structure isn't a list"
-      %XDR.Error.Enum{message: msg}
+      new("The declaration inside the Enum structure isn't a list")
     end
 
     def exception(:not_an_atom) do
-      msg = "The name of the key which you try to encode isn't an atom"
-      %XDR.Error.Enum{message: msg}
+      new("The name of the key which you try to encode isn't an atom")
     end
 
     def exception(:not_binary) do
-      msg =
-        "The value which you try to decode must be a binary value, for example: <<0, 0, 0, 2>>"
-
-      %XDR.Error.Enum{message: msg}
+      new("The value which you try to decode must be a binary value, for example: <<0, 0, 0, 2>>")
     end
 
     def exception(:invalid_key) do
-      msg = "The key which you try to encode doesn't belong to the current declarations"
-
-      %XDR.Error.Enum{message: msg}
+      new("The key which you try to encode doesn't belong to the current declarations")
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.Enum{message: msg}
   end
 
   defmodule Bool do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.Bool module
+    This module contains the definition of `XDR.Error.Bool` exception that may be raised by the `XDR.Bool` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.Bool module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-
-      ### Example
-        def exception(:not_list) do
-          ...
-        end
-
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.Bool` exception with the message of the `error_type` passed.
     """
     def exception(:not_boolean) do
-      msg = "The value which you try to encode is not a boolean"
-      %XDR.Error.Bool{message: msg}
+      new("The value which you try to encode is not a boolean")
     end
 
     def exception(:invalid_value) do
-      msg = "The value which you try to decode must be <<0, 0, 0, 0>> or <<0, 0, 0, 1>>"
-      %XDR.Error.Bool{message: msg}
+      new("The value which you try to decode must be <<0, 0, 0, 0>> or <<0, 0, 0, 1>>")
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.Bool{message: msg}
   end
 
   defmodule HyperInt do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.HyperInt module
+    This module contains the definition of `XDR.Error.HyperInt` exception that may be raised by the `XDR.HyperInt` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.HyperInt module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-
-      ### Example
-        def exception(:not_list) do
-          ...
-        end
-
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.HyperInt` exception with the message of the `error_type` passed.
     """
     def exception(:not_integer) do
-      msg = "The value which you try to encode is not an integer"
-      %XDR.Error.HyperInt{message: msg}
+      new("The value which you try to encode is not an integer")
     end
 
     def exception(:not_binary) do
-      msg =
+      new(
         "The value which you try to decode must be a binary value, for example: <<0, 0, 0, 0, 0, 0, 0, 5>>"
-
-      %XDR.Error.HyperInt{message: msg}
+      )
     end
 
     def exception(:exceed_upper_limit) do
-      msg =
+      new(
         "The integer which you try to encode exceed the upper limit of an Hyper Integer, the value must be less than 9_223_372_036_854_775_807"
-
-      %XDR.Error.HyperInt{message: msg}
+      )
     end
 
     def exception(:exceed_lower_limit) do
-      msg =
+      new(
         "The integer which you try to encode exceed the lower limit of an Hyper Integer, the value must be more than -9_223_372_036_854_775_808"
-
-      %XDR.Error.HyperInt{message: msg}
+      )
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.HyperInt{message: msg}
   end
 
   defmodule HyperUInt do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.HyperUInt module
+    This module contains the definition of `XDR.Error.HyperUInt` exception that may be raised by the `XDR.HyperUInt` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.HyperUInt module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-
-      ### Example
-        def exception(:not_list) do
-          ...
-        end
-
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.HyperUInt` exception with the message of the `error_type` passed.
     """
     def exception(:not_integer) do
-      msg = "The value which you try to encode is not an integer"
-      %XDR.Error.HyperUInt{message: msg}
+      new("The value which you try to encode is not an integer")
     end
 
     def exception(:not_binary) do
-      msg =
+      new(
         "The value which you try to decode must be a binary value, for example: <<0, 0, 0, 0, 0, 0, 0, 5>>"
-
-      %XDR.Error.HyperUInt{message: msg}
+      )
     end
 
     def exception(:exceed_upper_limit) do
-      msg =
+      new(
         "The integer which you try to encode exceed the upper limit of an Hyper Unsigned Integer, the value must be less than 18_446_744_073_709_551_615"
-
-      %XDR.Error.HyperUInt{message: msg}
+      )
     end
 
     def exception(:exceed_lower_limit) do
-      msg =
+      new(
         "The integer which you try to encode exceed the lower limit of an Hyper Unsigned Integer, the value must be more than 0"
-
-      %XDR.Error.HyperUInt{message: msg}
+      )
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.HyperUInt{message: msg}
   end
 
   defmodule Float do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.Float module
+    This module contains the definition of `XDR.Error.Float` exception that may be raised by the `XDR.Float` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.Float module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-
-      ### Example
-        def exception(:not_integer) do
-          ...
-        end
-
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.Float` exception with the message of the `error_type` passed.
     """
     def exception(:not_number) do
-      msg = "The value which you try to encode is not an integer or float value"
-      %XDR.Error.Float{message: msg}
+      new("The value which you try to encode is not an integer or float value")
     end
 
     def exception(:not_binary) do
-      msg =
-        "The value which you try to decode must be a binary value, for example: <<0, 0, 0, 2>>"
-
-      %XDR.Error.Float{message: msg}
+      new("The value which you try to decode must be a binary value, for example: <<0, 0, 0, 2>>")
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.Float{message: msg}
   end
 
   defmodule DoubleFloat do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.DoubleFloat module
+    This module contains the definition of `XDR.Error.DoubleFloat` exception that may be raised by the `XDR.DoubleFloat` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.DoubleFloat module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-
-      ### Example
-        def exception(:not_integer) do
-          ...
-        end
-
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.DoubleFloat` exception with the message of the `error_type` passed.
     """
     def exception(:not_number) do
-      msg = "The value which you try to encode is not an integer or float value"
-      %XDR.Error.DoubleFloat{message: msg}
+      new("The value which you try to encode is not an integer or float value")
     end
 
     def exception(:not_binary) do
-      msg =
+      new(
         "The value which you try to decode must be a binary value, for example: <<0, 0, 0, 0, 0, 0, 0, 5>>"
-
-      %XDR.Error.DoubleFloat{message: msg}
+      )
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.DoubleFloat{message: msg}
   end
 
   defmodule FixedOpaque do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.FixedOpaque module
+    This module contains the definition of `XDR.Error.FixedOpaque` exception that may be raised by the `XDR.FixedOpaque` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.FixedOpaque module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-
-      ### Example
-        def exception(:not_integer) do
-          ...
-        end
-
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.FixedOpaque` exception with the message of the `error_type` passed.
     """
     def exception(:not_number) do
-      msg = "The value which you pass through parameters is not an integer"
-      %XDR.Error.FixedOpaque{message: msg}
+      new("The value which you pass through parameters is not an integer")
     end
 
     def exception(:not_binary) do
-      msg =
+      new(
         "The value which you pass through parameters must be a binary value, for example: <<0, 0, 0, 5>>"
-
-      %XDR.Error.FixedOpaque{message: msg}
+      )
     end
 
     def exception(:invalid_length) do
-      msg =
+      new(
         "The length that is passed through parameters must be equal or less to the byte size of the XDR to complete"
-
-      %XDR.Error.FixedOpaque{message: msg}
+      )
     end
 
     def exception(:exceed_length) do
-      msg = "The length is bigger than the byte size of the XDR"
-
-      %XDR.Error.FixedOpaque{message: msg}
+      new("The length is bigger than the byte size of the XDR")
     end
 
     def exception(:not_valid_binary) do
-      msg = "The binary size of the binary which you try to decode must be a multiple of 4"
-
-      %XDR.Error.FixedOpaque{message: msg}
+      new("The binary size of the binary which you try to decode must be a multiple of 4")
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.FixedOpaque{message: msg}
   end
 
   defmodule VariableOpaque do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.VariableOpaque module
+    This module contains the definition of `XDR.Error.VariableOpaque` exception that may be raised by the `XDR.VariableOpaque` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.VariableOpaque module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-
-      ### Example
-        def exception(:not_integer) do
-          ...
-        end
-
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.VariableOpaque` exception with the message of the `error_type` passed.
     """
     def exception(:not_number) do
-      msg = "The value which you pass through parameters is not an integer"
-      %XDR.Error.VariableOpaque{message: msg}
+      new("The value which you pass through parameters is not an integer")
     end
 
     def exception(:not_binary) do
-      msg =
+      new(
         "The value which you pass through parameters must be a binary value, for example: <<0, 0, 0, 5>>"
-
-      %XDR.Error.VariableOpaque{message: msg}
+      )
     end
 
     def exception(:invalid_length) do
-      msg =
+      new(
         "The max length that is passed through parameters must be biger to the byte size of the XDR"
-
-      %XDR.Error.VariableOpaque{message: msg}
+      )
     end
 
     def exception(:exceed_lower_bound) do
-      msg = "The minimum value of the length of the variable is 0"
-
-      %XDR.Error.VariableOpaque{message: msg}
+      new("The minimum value of the length of the variable is 0")
     end
 
     def exception(:exceed_upper_bound) do
-      msg = "The maximum value of the length of the variable is 4_294_967_295"
-
-      %XDR.Error.VariableOpaque{message: msg}
+      new("The maximum value of the length of the variable is 4_294_967_295")
     end
 
     def exception(:length_over_max) do
-      msg =
+      new(
         "The number which represents the length from decode the opaque as UInt is bigger than the defined max (max by default is 4_294_967_295)"
-
-      %XDR.Error.VariableOpaque{message: msg}
+      )
     end
 
     def exception(:length_over_rest) do
-      msg = "The XDR has an invalid length, it must be less than byte-size of the rest"
-
-      %XDR.Error.VariableOpaque{message: msg}
+      new("The XDR has an invalid length, it must be less than byte-size of the rest")
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.VariableOpaque{message: msg}
   end
 
   defmodule String do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.String module
+    This module contains the definition of `XDR.Error.String` exception that may be raised by the `XDR.String` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.String module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-
-      ### Example
-        def exception(:not_integer) do
-          ...
-        end
-
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.String` exception with the message of the `error_type` passed.
     """
     def exception(:not_bitstring) do
-      msg = "the value which you try to encode must be a bitstring value"
-      %XDR.Error.String{message: msg}
+      new("the value which you try to encode must be a bitstring value")
     end
 
     def exception(:not_binary) do
-      msg = "the value which you try to decode must be a binary value"
-      %XDR.Error.String{message: msg}
+      new("the value which you try to decode must be a binary value")
     end
+
+    @spec new(msg :: binary()) :: struct()
+    defp new(msg), do: %XDR.Error.String{message: msg}
   end
 
   defmodule FixedArray do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.FixedArray module
+    This module contains the definition of `XDR.Error.FixedArray` exception that may be raised by the `XDR.FixedArray` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.FixedArray module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-
-      ### Example
-        def exception(:not_integer) do
-          ...
-        end
-
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.FixedArray` exception with the message of the `error_type` passed.
     """
     def exception(:invalid_length) do
-      msg = "the length of the array and the length must be the same"
-      %XDR.Error.FixedArray{message: msg}
+      new("the length of the array and the length must be the same")
     end
 
     def exception(:not_list) do
-      msg = "the value which you try to encode must be a list"
-      %XDR.Error.FixedArray{message: msg}
+      new("the value which you try to encode must be a list")
     end
 
     def exception(:not_number) do
-      msg = "the length received by parameter must be an integer"
-      %XDR.Error.FixedArray{message: msg}
+      new("the length received by parameter must be an integer")
     end
 
     def exception(:not_binary) do
-      msg = "the value which you try to decode must be a binary value"
-      %XDR.Error.FixedArray{message: msg}
+      new("the value which you try to decode must be a binary value")
     end
 
     def exception(:not_valid_binary) do
-      msg = "the value which you try to decode must have a multiple of 4 byte-size"
-      %XDR.Error.FixedArray{message: msg}
+      new("the value which you try to decode must have a multiple of 4 byte-size")
     end
+
+    def exception(:invalid_type) do
+      new("the type must be a module")
+    end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.FixedArray{message: msg}
   end
 
   defmodule VariableArray do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.VariableArray module
+    This module contains the definition of `XDR.Error.VariableArray` exception that may be raised by the `XDR.VariableArray` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.VariableArray module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-
-      ### Example
-        def exception(:not_integer) do
-          ...
-        end
-
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.VariableArray` exception with the message of the `error_type` passed.
     """
     def exception(:not_list) do
-      msg = "the value which you try to encode must be a list"
-      %XDR.Error.VariableArray{message: msg}
+      new("the value which you try to encode must be a list")
     end
 
     def exception(:not_number) do
-      msg = "the max length must be an integer value"
-      %XDR.Error.VariableArray{message: msg}
+      new("the max length must be an integer value")
     end
 
     def exception(:not_binary) do
-      msg =
+      new(
         "The value which you pass through parameters must be a binary value, for example: <<0, 0, 0, 5>>"
-
-      %XDR.Error.VariableArray{message: msg}
+      )
     end
 
     def exception(:exceed_lower_bound) do
-      msg = "The minimum value of the length of the variable is 1"
-
-      %XDR.Error.VariableArray{message: msg}
+      new("The minimum value of the length of the variable is 1")
     end
 
     def exception(:exceed_upper_bound) do
-      msg = "The maximum value of the length of the variable is 4_294_967_295"
-
-      %XDR.Error.VariableArray{message: msg}
+      new("The maximum value of the length of the variable is 4_294_967_295")
     end
 
     def exception(:length_over_max) do
-      msg =
+      new(
         "The number which represents the length from decode the opaque as UInt is bigger than the defined max"
-
-      %XDR.Error.VariableArray{message: msg}
+      )
     end
 
     def exception(:invalid_length) do
-      msg = "The length of the binary exceeds the max_length of the type"
-
-      %XDR.Error.VariableArray{message: msg}
+      new("The length of the binary exceeds the max_length of the type")
     end
 
     def exception(:invalid_binary) do
-      msg =
+      new(
         "The data which you try to decode has an invalid number of bytes, it must be equal to or greater than the size of the array multiplied by 4"
-
-      %XDR.Error.VariableArray{message: msg}
+      )
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.VariableArray{message: msg}
   end
 
   defmodule Struct do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.Struct module
+    This module contains the definition of `XDR.Error.Struct` exception that may be raised by the `XDR.Struct` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.Struct module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-      ### Example
-        def exception(:not_integer) do
-          ...
-        end
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.Struct` exception with the message of the `error_type` passed.
     """
     def exception(:not_list) do
-      msg = "The :components received by parameter must be a keyword list"
-      %XDR.Error.Struct{message: msg}
+      new("The :components received by parameter must be a keyword list")
     end
 
     def exception(:empty_list) do
-      msg = "The :components must not be empty, it must be a keyword list"
-      %XDR.Error.Struct{message: msg}
+      new("The :components must not be empty, it must be a keyword list")
     end
 
     def exception(:not_binary) do
-      msg =
-        "The :struct received by parameter must be a binary value, for example: <<0, 0, 0, 5>>"
-
-      %XDR.Error.Struct{message: msg}
+      new("The :struct received by parameter must be a binary value, for example: <<0, 0, 0, 5>>")
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.Struct{message: msg}
   end
 
   defmodule Union do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.Union module
+    This module contains the definition of `XDR.Error.Union` exception that may be raised by the `XDR.Union` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.Union module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-      ### Example
-        def exception(:not_integer) do
-          ...
-        end
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.Union` exception with the message of the `error_type` passed.
     """
     def exception(:not_list) do
-      msg =
+      new(
         "The :declarations received by parameter must be a keyword list which belongs to an XDR.Enum"
-
-      %XDR.Error.Union{message: msg}
+      )
     end
 
     def exception(:not_binary) do
-      msg =
+      new(
         "The :identifier received by parameter must be a binary value, for example: <<0, 0, 0, 5>>"
-
-      %XDR.Error.Union{message: msg}
+      )
     end
 
     def exception(:not_number) do
-      msg = "The value which you try to decode is not an integer value"
-      %XDR.Error.Union{message: msg}
+      new("The value which you try to decode is not an integer value")
     end
 
     def exception(:not_atom) do
-      msg = "The :identifier which you try to decode from the Enum Union is not an atom"
-      %XDR.Error.Union{message: msg}
+      new("The :identifier which you try to decode from the Enum Union is not an atom")
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.Union{message: msg}
   end
 
   defmodule Void do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.Void module
+    This module contains the definition of `XDR.Error.Void` exception that may be raised by the `XDR.Void` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.Void module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-      ### Example
-        def exception(:not_integer) do
-          ...
-        end
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.Void` exception with the message of the `error_type` passed.
     """
     def exception(:not_binary) do
-      msg =
-        "The value which you try to decode must be a binary value, for example: <<0, 0, 0, 5>>"
-
-      %XDR.Error.Void{message: msg}
+      new("The value which you try to decode must be a binary value, for example: <<0, 0, 0, 5>>")
     end
 
     def exception(:not_void) do
-      msg = "The value which you try to encode is not void"
-
-      %XDR.Error.Void{message: msg}
+      new("The value which you try to encode is not void")
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.Void{message: msg}
   end
 
   defmodule Optional do
     @moduledoc """
-    This module is in charge of containing the errors that may be raised by the XDR.Optional module
+    This module contains the definition of `XDR.Error.Optional` exception that may be raised by the `XDR.Optional` module.
     """
+
     defexception [:message]
 
     @impl true
     @doc """
-    This function is in charge of raise the errors that can be returned by XDR.Optional module
-      ## Parameters:
-        the function only have one parameter that is an atom which represents the type of error returned by the module
-      ### Example
-        def exception(:not_integer) do
-          ...
-        end
-    Raises an exception error when the error is produced
+    Create a `XDR.Error.Optional` exception with the message of the `error_type` passed.
     """
     def exception(:not_valid) do
-      msg = "The value which you try to encode must be Int, UInt or Enum"
-
-      %XDR.Error.Optional{message: msg}
+      new("The value which you try to encode must be Int, UInt or Enum")
     end
 
     def exception(:not_binary) do
-      msg = "The value which you try to decode must be a binary value"
-
-      %XDR.Error.Optional{message: msg}
+      new("The value which you try to decode must be a binary value")
     end
 
     def exception(:not_module) do
-      msg = "The type of the optional value must be the module which it belongs"
-
-      %XDR.Error.Optional{message: msg}
+      new("The type of the optional value must be the module which it belongs")
     end
+
+    @spec new(msg :: String.t()) :: struct()
+    defp new(msg), do: %XDR.Error.Optional{message: msg}
   end
 end

--- a/lib/xdr/bool.ex
+++ b/lib/xdr/bool.ex
@@ -1,27 +1,33 @@
 defmodule XDR.Bool do
-  @behaviour XDR.Declaration
   @moduledoc """
-  This module is in charge of process the boolean types based on the RFC4056 XDR Standard
+  This module manages the `Boolean` type based on the RFC4506 XDR Standard.
   """
+
+  @behaviour XDR.Declaration
+
   alias XDR.Enum
-  alias XDR.Error.Bool
+  alias XDR.Error.Bool, as: BoolError
 
   @boolean [false: 0, true: 1]
 
   defstruct declarations: @boolean, identifier: nil
 
+  @typedoc """
+  `XDR.Bool` struct type specification.
+  """
   @type t :: %XDR.Bool{declarations: keyword(), identifier: boolean()}
 
-  @spec new(atom()) :: t()
-  def new(identifier), do: %XDR.Bool{declarations: @boolean, identifier: identifier}
+  @doc """
+  Create a new `XDR.Bool` structure from the `identifier` passed either `false` or `true`.
+  """
+  @spec new(identifier :: atom()) :: t
+  def new(identifier), do: %XDR.Bool{identifier: identifier}
 
   @impl XDR.Declaration
   @doc """
-  This function is in charge of encode the boolean data to a binary representation
-
-  returns an ok tuple with the boolean encoded into an XDR value
+  Encode a `XDR.Bool` structure into a XDR format.
   """
-  @spec encode_xdr(t()) :: {:ok, binary} | {:error, :not_boolean}
+  @spec encode_xdr(boolean :: t) :: {:ok, binary} | {:error, :not_boolean}
   def encode_xdr(%XDR.Bool{identifier: identifier}) when not is_boolean(identifier),
     do: {:error, :not_boolean}
 
@@ -29,50 +35,44 @@ defmodule XDR.Bool do
 
   @impl XDR.Declaration
   @doc """
-  This function is in charge of encode the boolean data to a binary representation
-
-  returns the boolean encoded into an XDR value
+  Encode a `XDR.Bool` structure into a XDR format.
+  If the structure received is not `XDR.Bool` or the identifier is not boolean, an exception is raised.
   """
-  @spec encode_xdr!(t()) :: binary()
+  @spec encode_xdr!(boolean :: t) :: binary()
   def encode_xdr!(boolean) do
     case encode_xdr(boolean) do
       {:ok, binary} -> binary
-      {:error, reason} -> raise(Bool, reason)
+      {:error, reason} -> raise(BoolError, reason)
     end
   end
 
   @impl XDR.Declaration
   @doc """
-  This function is in charge of decode XDR data which represents a boolean value
-
-  returns an ok tuple with the boolean decoded from an XDR value
+  Decode the Boolean in XDR format to a `XDR.Bool` structure.
   """
   @spec decode_xdr(bytes :: binary, struct :: t | any) ::
           {:ok, {t, binary}} | {:error, :invalid_value}
-  def decode_xdr(bytes, struct \\ %XDR.Bool{declarations: @boolean})
+  def decode_xdr(bytes, struct \\ %XDR.Bool{})
   def decode_xdr(bytes, _struct) when not is_binary(bytes), do: {:error, :invalid_value}
 
   def decode_xdr(bytes, struct) do
     {enum, rest} = Enum.decode_xdr!(bytes, struct)
-
     decoded_bool = new(enum.identifier)
-
     {:ok, {decoded_bool, rest}}
   end
 
   @impl XDR.Declaration
   @doc """
-  This function is in charge of decode XDR data which represents a boolean value
-
-  returns the boolean decoded from an XDR value
+  Decode the Boolean in XDR format to a `XDR.Bool` structure.
+  If the binary is not a valid boolean, an exception is raised.
   """
-  @spec decode_xdr!(bytes :: binary, struct :: t | any) :: {t(), binary}
-  def decode_xdr!(bytes, struct \\ %XDR.Bool{declarations: @boolean})
+  @spec decode_xdr!(bytes :: binary, struct :: t | any) :: {t, binary}
+  def decode_xdr!(bytes, struct \\ %XDR.Bool{})
 
   def decode_xdr!(bytes, struct) do
     case decode_xdr(bytes, struct) do
       {:ok, result} -> result
-      {:error, reason} -> raise(Bool, reason)
+      {:error, reason} -> raise(BoolError, reason)
     end
   end
 end

--- a/lib/xdr/declaration.ex
+++ b/lib/xdr/declaration.ex
@@ -1,18 +1,17 @@
 defmodule XDR.Declaration do
   @moduledoc """
-    Behaviour definition that is in charge of keeping the types declared by the RFC4506 standard with these specifications
+  Behaviour definition for the types declared based on RFC4506 XDR standard.
   """
-  alias XDR.Error
 
-  # encode XDR for any type returns a tuple with the resulted binary value
-  @callback encode_xdr(struct) :: {:ok, binary} | Error.t()
+  @doc "Encode XDR for any type returns a tuple with the resulted binary value."
+  @callback encode_xdr(struct) :: {:ok, binary} | {:error, atom()}
 
-  # encode XDR for any type returns the resulted binary value
-  @callback encode_xdr!(struct) :: binary | Error.t()
+  @doc "Encode XDR for any type returns the resulted binary value."
+  @callback encode_xdr!(struct) :: binary | {:error, atom()}
 
-  # decode XDR for any type returns a tuple with the converted value
-  @callback decode_xdr(binary, term) :: {:ok, {term, binary}} | Error.t()
+  @doc "Encode XDR for any type returns a tuple with the converted value."
+  @callback decode_xdr(binary, term) :: {:ok, {term, binary}} | {:error, atom()}
 
-  # decode XDR for any type returns the resulted converted value
-  @callback decode_xdr!(binary, term) :: {term, binary} | Error.t()
+  @doc "Decode XDR for any type returns the resulted converted value."
+  @callback decode_xdr!(binary, term) :: {term, binary} | {:error, atom()}
 end

--- a/lib/xdr/double_float.ex
+++ b/lib/xdr/double_float.ex
@@ -1,36 +1,32 @@
 defmodule XDR.DoubleFloat do
-  @behaviour XDR.Declaration
   @moduledoc """
-  This module is in charge of process the Double-Precision Floating-Point types based on the RFC4506 XDR Standard
+  This module manages the `Double-Precision Floating-Point` type based on the RFC4506 XDR Standard.
   """
 
-  defstruct float: nil
+  @behaviour XDR.Declaration
 
-  @typedoc """
-  Every double float structure has a float which represent the Double-Precision Floating-Point value which you try to encode
-  """
-  @type t :: %XDR.DoubleFloat{float: integer | float | binary}
+  alias XDR.Error.DoubleFloat, as: DoubleFloatError
 
-  alias XDR.Error.DoubleFloat
-
-  @doc """
-  this function provides an easy way to create an XDR.DoubleFloat type
-
-  returns a XDR.DoubleFloat struct with the value received as parameter
-  """
-  @spec new(float :: float | integer | binary) :: t()
-  def new(float), do: %XDR.DoubleFloat{float: float}
+  defstruct [:float]
 
   defguard valid_float?(value) when is_float(value) or is_integer(value)
 
+  @typedoc """
+  `XDR.DoubleFloat` struct type specification.
+  """
+  @type t :: %XDR.DoubleFloat{float: integer | float | binary}
+
+  @doc """
+  Create a new `XDR.DoubleFloat` structure from the `float` passed.
+  """
+  @spec new(float :: float | integer | binary) :: t
+  def new(float), do: %XDR.DoubleFloat{float: float}
+
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encoding a Double Floating Point value into an XDR if the parameters are wrong an error will be raised,
-  it receives an XDR.DoubleFloat structure which contains the Double-Precision Floating-Point to encode
-
-  Returns a tuple with the XDR resulted from encoding the Double Floating Point value
+  Encode a `XDR.DoubleFloat` structure into a XDR format.
   """
-  @spec encode_xdr(t()) :: {:ok, binary()} | {:error, :not_number}
+  @spec encode_xdr(double_float :: t) :: {:ok, binary()} | {:error, :not_number}
   def encode_xdr(%XDR.DoubleFloat{float: float}) when not valid_float?(float),
     do: {:error, :not_number}
 
@@ -38,33 +34,27 @@ defmodule XDR.DoubleFloat do
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encoding a Double Floating Point value into an XDR if the parameters are wrong an error will be raised,
-  it receives an XDR.DoubleFloat structure which contains the Double-Precision Floating-Point to encode
-
-  Returns the XDR resulted from encoding the Double Floating Point value
+  Encode a `XDR.DoubleFloat` structure into a XDR format.
+  If the `double_float` is not valid, an exception is raised.
   """
-  @spec encode_xdr!(t()) :: binary()
-  def encode_xdr!(float) do
-    case encode_xdr(float) do
+  @spec encode_xdr!(double_float :: t) :: binary()
+  def encode_xdr!(double_float) do
+    case encode_xdr(double_float) do
       {:ok, binary} -> binary
-      {:error, reason} -> raise(DoubleFloat, reason)
+      {:error, reason} -> raise(DoubleFloatError, reason)
     end
   end
 
   @impl XDR.Declaration
   @doc """
-  This function is in charge of decode the XDR value which represents an Double Floating Point value if the parameters are wrong
-  an error will be raised, it receives an XDR.DoubleFloat structure which contanis the binary to decode
-
-  Returns a tuple with the Double Floating Point resulted from decode the XDR value and its remaining bits
+  Decode the Double-Precision Floating-Point in XDR format to a `XDR.DoubleFloat` structure.
   """
-  @spec decode_xdr(bytes :: binary, opts :: any) :: {:ok, {t(), binary()}} | {:error, :not_binary}
-  def decode_xdr(bytes, opts \\ nil)
+  @spec decode_xdr(bytes :: binary, double_float :: t) ::
+          {:ok, {t, binary()}} | {:error, :not_binary}
+  def decode_xdr(bytes, double_float \\ nil)
+  def decode_xdr(bytes, _double_float) when not is_binary(bytes), do: {:error, :not_binary}
 
-  def decode_xdr(bytes, _opts) when not is_binary(bytes),
-    do: {:error, :not_binary}
-
-  def decode_xdr(bytes, _opts) do
+  def decode_xdr(bytes, _double_float) do
     <<float::big-signed-float-size(64), rest::binary>> = bytes
 
     decoded_float = new(float)
@@ -74,18 +64,16 @@ defmodule XDR.DoubleFloat do
 
   @impl XDR.Declaration
   @doc """
-  This function is in charge of decode the XDR value which represents an Double Floating Point value if the parameters are wrong
-  an error will be raised, it receives an XDR.DoubleFloat structure which contanis the binary to decode
-
-  Returns the Double Floating Point resulted from decode the XDR value and its remaining bits
+  Decode the Double-Precision Floating-Point in XDR format to a `XDR.DoubleFloat` structure.
+  If the binaries are not valid, an exception is raised.
   """
-  @spec decode_xdr!(bytes :: binary, opts :: any) :: {t(), binary()}
-  def decode_xdr!(bytes, opts \\ nil)
+  @spec decode_xdr!(bytes :: binary, double_float :: t) :: {t, binary()}
+  def decode_xdr!(bytes, double_float \\ nil)
 
-  def decode_xdr!(bytes, opts) do
-    case decode_xdr(bytes, opts) do
+  def decode_xdr!(bytes, double_float) do
+    case decode_xdr(bytes, double_float) do
       {:ok, result} -> result
-      {:error, reason} -> raise(DoubleFloat, reason)
+      {:error, reason} -> raise(DoubleFloatError, reason)
     end
   end
 end

--- a/lib/xdr/fixed_array.ex
+++ b/lib/xdr/fixed_array.ex
@@ -1,105 +1,93 @@
 defmodule XDR.FixedArray do
-  @behaviour XDR.Declaration
   @moduledoc """
-  this module is in charge of process the Fixed Array types based on the RFC4506 XDR Standard
+  This module manages the `Fixed-Length Array` type based on the RFC4506 XDR Standard.
   """
 
-  defstruct elements: nil, type: nil, length: nil
+  @behaviour XDR.Declaration
+
+  alias XDR.Error.FixedArray, as: FixedArrayError
+
+  defstruct [:elements, :type, :length]
 
   @typedoc """
-  Every FixedArray structure has the list of elements to encode,the type of these elements and the length of the list
+  `XDR.FixedArray` structure type specification.
   """
   @type t :: %XDR.FixedArray{elements: list | nil, type: module, length: integer}
 
-  alias XDR.Error.FixedArray
-
   @doc """
-  this function provides an easy way to create an XDR.FixedArray type
-
-  returns a XDR.FixedArray struct with the value received as parameter
+  Create a new `XDR.FixedArray` structure with the `elements`, `type` and `length` passed.
   """
-  @spec new(elements :: list | binary, type :: module, length :: integer) :: t()
+  @spec new(elements :: list | binary, type :: module, length :: integer) :: t
   def new(elements, type, length),
     do: %XDR.FixedArray{elements: elements, type: type, length: length}
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encode a list into an XDR, it receives an XDR.FixedArray structure which contains the
-  data needed to encode the fixed array
-
-  returns an :ok tuple with the resulted XDR
+  Encode a `XDR.FixedArray` structure into a XDR format.
   """
-  @spec encode_xdr(map()) :: {:ok, binary} | {:error, :not_number | :invalid_length | :not_list}
-  def encode_xdr(%{length: length}) when not is_integer(length),
-    do: {:error, :not_number}
+  @spec encode_xdr(fixed_array :: t) ::
+          {:ok, binary} | {:error, :not_number | :invalid_length | :not_list}
+  def encode_xdr(%{length: length}) when not is_integer(length), do: {:error, :not_number}
 
-  def encode_xdr(%{elements: elements, length: length})
-      when length(elements) !== length,
-      do: {:error, :invalid_length}
+  def encode_xdr(%{elements: elements, length: length}) when length(elements) !== length,
+    do: {:error, :invalid_length}
 
-  def encode_xdr(%{elements: elements}) when not is_list(elements),
-    do: {:error, :not_list}
+  def encode_xdr(%{elements: elements}) when not is_list(elements), do: {:error, :not_list}
+  def encode_xdr(%{type: type}) when not is_atom(type), do: {:error, :invalid_type}
 
   def encode_xdr(%{elements: elements, type: type}) do
-    {:ok,
-     Enum.reduce(elements, <<>>, fn element, bytes ->
-       bytes <> apply(type, :encode_xdr!, [apply(type, :new, [element])])
-     end)}
+    binary =
+      Enum.reduce(elements, <<>>, fn element, bytes -> bytes <> encode_element(element, type) end)
+
+    {:ok, binary}
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encode a list into an XDR, it receives an XDR.FixedArray structure which contains the
-  data needed to encode the fixed array
-
-  returns the resulted XDR
+  Encode a `XDR.FixedArray` structure into a XDR format.
+  If the `fixed_array` is not valid, an exception is raised.
   """
-  @spec encode_xdr!(map()) :: binary()
+  @spec encode_xdr!(fixed_array :: t) :: binary()
   def encode_xdr!(fixed_array) do
     case encode_xdr(fixed_array) do
       {:ok, result} -> result
-      {:error, reason} -> raise(FixedArray, reason)
+      {:error, reason} -> raise(FixedArrayError, reason)
     end
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decode an XDR into a list, it receives an XDR.FixedArray structure which contains the data
-  to decode the binary
-
-  returns an :ok tuple with the resulted list
+  Decode the Fixed-Length Array in XDR format to a `XDR.FixedArray` structure.
   """
-  @spec decode_xdr(bytes :: binary, struct :: map()) ::
+  @spec decode_xdr(bytes :: binary, fixed_array :: t | map()) ::
           {:ok, {list, binary}} | {:error, :not_number | :not_binary | :not_valid_binary}
-  def decode_xdr(_bytes, %{length: length}) when not is_integer(length),
-    do: {:error, :not_number}
-
-  def decode_xdr(bytes, _struct) when not is_binary(bytes),
-    do: {:error, :not_binary}
+  def decode_xdr(_bytes, %{length: length}) when not is_integer(length), do: {:error, :not_number}
+  def decode_xdr(bytes, _struct) when not is_binary(bytes), do: {:error, :not_binary}
 
   def decode_xdr(bytes, _struct) when rem(byte_size(bytes), 4) != 0,
     do: {:error, :not_valid_binary}
 
-  def decode_xdr(bytes, %{type: type, length: length}) do
-    {decoded_array, rest} = decode_elements_from_fixed_array(type, [], bytes, length)
+  def decode_xdr(_bytes, %{type: type}) when not is_atom(type), do: {:error, :invalid_type}
 
-    {:ok, {Enum.reverse(decoded_array), rest}}
+  def decode_xdr(bytes, %{type: type, length: length}) do
+    {:ok, decode_elements_from_fixed_array(type, [], bytes, length)}
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decode an XDR into a list, it receives an XDR.FixedArray structure which contains the data
-  to decode the binary
-
-  returns the resulted list
+  Decode the Fixed-Length Array in XDR format to a `XDR.FixedArray` structure.
+  If the binaries are not valid, an exception is raised.
   """
-  @spec decode_xdr!(bytes :: binary, struct :: map()) :: {list, binary}
-  def decode_xdr!(bytes, struct) do
-    case decode_xdr(bytes, struct) do
+  @spec decode_xdr!(bytes :: binary, fixed_array :: t | map()) :: {list, binary}
+  def decode_xdr!(bytes, fixed_array) do
+    case decode_xdr(bytes, fixed_array) do
       {:ok, result} -> result
-      {:error, reason} -> raise(FixedArray, reason)
+      {:error, reason} -> raise(FixedArrayError, reason)
     end
   end
+
+  @spec encode_element(element :: any(), type :: module()) :: binary()
+  defp encode_element(element, type), do: element |> type.new() |> type.encode_xdr!()
 
   @spec decode_elements_from_fixed_array(
           type :: module,
@@ -107,10 +95,10 @@ defmodule XDR.FixedArray do
           rest :: binary,
           array_length :: integer
         ) :: {list, binary}
-  defp decode_elements_from_fixed_array(_type, acc, rest, 0), do: {acc, rest}
+  defp decode_elements_from_fixed_array(_type, acc, rest, 0), do: {Enum.reverse(acc), rest}
 
   defp decode_elements_from_fixed_array(type, acc, bytes, array_length) do
-    {decoded, rest} = apply(type, :decode_xdr!, [bytes])
+    {decoded, rest} = type.decode_xdr!(bytes)
     decode_elements_from_fixed_array(type, [decoded | acc], rest, array_length - 1)
   end
 end

--- a/lib/xdr/fixed_opaque.ex
+++ b/lib/xdr/fixed_opaque.ex
@@ -1,80 +1,67 @@
 defmodule XDR.FixedOpaque do
-  @behaviour XDR.Declaration
   @moduledoc """
-  This module is in charge of process the Fixed Length Opaque based on the RFC4506 XDR Standard
+  This module manages the `Fixed-Length Opaque Data` type based on the RFC4506 XDR Standard.
   """
 
-  defstruct opaque: nil, length: nil
+  @behaviour XDR.Declaration
+
+  defstruct [:opaque, :length]
+
+  alias XDR.Error.FixedOpaque, as: FixedOpaqueError
 
   @typedoc """
-  Every Fixed length opaque structure has a opaque which represent the XDR to fix and its length
+  `XDR.FixedOpaque` structure type specification.
   """
   @type t :: %XDR.FixedOpaque{opaque: binary | nil, length: integer}
 
-  alias XDR.Error.FixedOpaque, as: FixedOpaqueErr
-
   @doc """
-  this function provides an easy way to create an XDR.FixedOpaque type
-
-  returns a XDR.FixedOpaque struct with the value received as parameter
+  Create a new `XDR.FixedOpaque` structure with the `opaque` and `length` passed.
   """
-  @spec new(opaque :: binary, length :: integer) :: t()
+  @spec new(opaque :: binary, length :: integer) :: t
   def new(opaque, length), do: %XDR.FixedOpaque{opaque: opaque, length: length}
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encode a Fixed Length Opaque into an XDR, it receives an XDR.FixedOpaque structure which
-  contains the bytes to encode
-
-  returns an ok tuple with the resulted XDR
+  Encode a `XDR.FixedOpaque` structure into a XDR format.
   """
-  @spec encode_xdr(map()) :: {:ok, binary} | {:error, :not_binary | :not_number | :invalid_length}
-  def encode_xdr(%{opaque: opaque}) when not is_binary(opaque),
-    do: {:error, :not_binary}
+  @spec encode_xdr(opaque :: t | map()) ::
+          {:ok, binary} | {:error, :not_binary | :not_number | :invalid_length}
+  def encode_xdr(%{opaque: opaque}) when not is_binary(opaque), do: {:error, :not_binary}
+  def encode_xdr(%{length: length}) when not is_integer(length), do: {:error, :not_number}
 
-  def encode_xdr(%{length: length}) when not is_integer(length),
-    do: {:error, :not_number}
+  def encode_xdr(%{opaque: opaque, length: length}) when length != byte_size(opaque),
+    do: {:error, :invalid_length}
 
-  def encode_xdr(%{opaque: opaque, length: length})
-      when length != byte_size(opaque),
-      do: {:error, :invalid_length}
-
-  def encode_xdr(%{opaque: opaque, length: length}) when rem(length, 4) === 0,
-    do: {:ok, opaque}
+  def encode_xdr(%{opaque: opaque, length: length}) when rem(length, 4) === 0, do: {:ok, opaque}
 
   def encode_xdr(%{opaque: opaque, length: length}) when rem(length, 4) != 0 do
-    new(opaque <> <<0>>, length + 1)
-    |> encode_xdr()
+    (opaque <> <<0>>) |> new(length + 1) |> encode_xdr()
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encode a Fixed Length Opaque into an XDR, it receives an XDR.FixedOpaque structure which
-  contains the bytes to encode
-
-  returns the resulted XDR
+  Encode a `XDR.FixedOpaque` structure into a XDR format.
+  If the `opaque` is not valid, an exception is raised.
   """
-  @spec encode_xdr!(map()) :: binary()
+  @spec encode_xdr!(opaque :: t | map()) :: binary()
   def encode_xdr!(opaque) do
     case encode_xdr(opaque) do
       {:ok, binary} -> binary
-      {:error, reason} -> raise(FixedOpaqueErr, reason)
+      {:error, reason} -> raise(FixedOpaqueError, reason)
     end
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decode an XDR into a Fixed Length Opaque, it receives an XDR.FixedOpaque structure which
-  contains the binary to decode
-
-  returns an :ok tuple with the resulted binary
+  Decode the Fixed-Length Opaque Data in XDR format to a `XDR.FixedOpaque` structure.
   """
-  @spec decode_xdr(bytes :: binary(), opts :: map()) ::
-          {:ok, {t(), binary}}
+  @spec decode_xdr(bytes :: binary(), opaque :: t | map()) ::
+          {:ok, {t, binary()}}
           | {:error, :not_binary | :not_valid_binary | :not_number | :exceed_length}
-  def decode_xdr(bytes, _opts) when not is_binary(bytes), do: {:error, :not_binary}
+  def decode_xdr(bytes, _opaque) when not is_binary(bytes), do: {:error, :not_binary}
 
-  def decode_xdr(bytes, _opts) when rem(byte_size(bytes), 4) != 0, do: {:error, :not_valid_binary}
+  def decode_xdr(bytes, _opaque) when rem(byte_size(bytes), 4) != 0,
+    do: {:error, :not_valid_binary}
 
   def decode_xdr(_bytes, %{length: length}) when not is_integer(length), do: {:error, :not_number}
 
@@ -88,26 +75,23 @@ defmodule XDR.FixedOpaque do
       bytes
 
     decoded_opaque = new(fixed_opaque, length)
-
     {:ok, {decoded_opaque, rest}}
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decode an XDR into a Fixed Length Opaque, it receives an XDR.FixedOpaque structure which
-  contains the binary to decode
-
-  returns the resulted binary
+  Decode the Fixed-Length Array in XDR format to a `XDR.FixedOpaque` structure.
+  If the binaries are not valid, an exception is raised.
   """
-  @spec decode_xdr!(bytes :: binary, opaque :: map()) :: {t(), binary()}
+  @spec decode_xdr!(bytes :: binary(), opaque :: t | map()) :: {t, binary()}
   def decode_xdr!(bytes, opaque) do
     case decode_xdr(bytes, opaque) do
       {:ok, result} -> result
-      {:error, reason} -> raise(FixedOpaqueErr, reason)
+      {:error, reason} -> raise(FixedOpaqueError, reason)
     end
   end
 
-  @spec get_required_padding(integer()) :: integer()
+  @spec get_required_padding(length :: integer()) :: integer()
   defp get_required_padding(length) when rem(length, 4) == 0, do: 0
   defp get_required_padding(length), do: 4 - rem(length, 4)
 end

--- a/lib/xdr/float.ex
+++ b/lib/xdr/float.ex
@@ -1,36 +1,32 @@
 defmodule XDR.Float do
-  @behaviour XDR.Declaration
   @moduledoc """
-  This module is in charge of process the Single-Precision Floating-Point types based on the RFC4506 XDR Standard
+  This module manages the `Floating-Point` type based on the RFC4506 XDR Standard.
   """
 
-  defstruct float: nil
+  @behaviour XDR.Declaration
 
-  @typedoc """
-  Every float structure has a float which represent the Single-Precision Floating-Point value which you try to encode
-  """
-  @type t :: %XDR.Float{float: integer | float | binary}
+  alias XDR.Error.Float, as: FloatError
 
-  alias XDR.Error.Float
-
-  @doc """
-  this function provides an easy way to create an XDR.Float type
-
-  returns a XDR.Float struct with the value received as parameter
-  """
-  @spec new(float :: float | integer | binary) :: t()
-  def new(float), do: %XDR.Float{float: float}
+  defstruct [:float]
 
   defguard valid_float?(value) when is_float(value) or is_integer(value)
 
+  @typedoc """
+  `XDR.Float` structure type specification.
+  """
+  @type t :: %XDR.Float{float: integer | float | binary}
+
+  @doc """
+  Create a new `XDR.Float` structure with the `float` passed.
+  """
+  @spec new(float :: float | integer | binary) :: t
+  def new(float), do: %XDR.Float{float: float}
+
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encoding a Floating Point value into an XDR if the parameters are wrong an error will be raised, it
-  receives an XDR.Float structure which contains the float value to encode
-
-  Returns a tuple with the XDR resulted from encoding the Floating Point value
+  Encode a `XDR.Float` structure into a XDR format.
   """
-  @spec encode_xdr(t()) :: {:ok, binary()} | {:error, :not_number}
+  @spec encode_xdr(float :: t) :: {:ok, binary} | {:error, :not_number}
   def encode_xdr(%XDR.Float{float: float}) when not valid_float?(float),
     do: {:error, :not_number}
 
@@ -38,54 +34,42 @@ defmodule XDR.Float do
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encoding a Floating Point value into an XDR if the parameters are wrong an error will be raised, it
-  receives an XDR.Float structure which contains the float value to encode
-
-  Returns the XDR resulted from encoding the Floating Point value
+  Encode a `XDR.Float` structure into a XDR format.
+  If the `float` is not valid, an exception is raised.
   """
-  @spec encode_xdr!(t()) :: binary()
+  @spec encode_xdr!(float :: t) :: binary
   def encode_xdr!(float) do
     case encode_xdr(float) do
       {:ok, binary} -> binary
-      {:error, reason} -> raise(Float, reason)
+      {:error, reason} -> raise(FloatError, reason)
     end
   end
 
   @impl XDR.Declaration
   @doc """
-  This function is in charge of decode the XDR value which represents an Floating Point value if the parameters are wrong
-  an error will be raised, it receives an XDR.Float structure which contains the binary to decode
-
-  Returns a tuple with the Floating Point resulted from decode the XDR value and its remaining bits
+  Decode the Floating-Point in XDR format to a `XDR.Float` structure.
   """
-  @spec decode_xdr(bytes :: binary, opts :: any) :: {:ok, {t(), binary()}} | {:error, :not_binary}
-  def decode_xdr(bytes, opts \\ nil)
+  @spec decode_xdr(bytes :: binary, float :: t) :: {:ok, {t, binary}} | {:error, :not_binary}
+  def decode_xdr(bytes, float \\ nil)
 
-  def decode_xdr(bytes, _opts) when not is_binary(bytes),
+  def decode_xdr(bytes, _float) when not is_binary(bytes),
     do: {:error, :not_binary}
 
-  def decode_xdr(bytes, _opts) do
-    <<float::big-signed-float-size(32), rest::binary>> = bytes
-
-    decoded_float = new(float)
-
-    {:ok, {decoded_float, rest}}
-  end
+  def decode_xdr(<<float::big-signed-float-size(32), rest::binary>>, _float),
+    do: {:ok, {new(float), rest}}
 
   @impl XDR.Declaration
   @doc """
-  This function is in charge of decode the XDR value which represents an Floating Point value if the parameters are wrong
-  an error will be raised, it receives an XDR.Float structure which contains the binary to decode
-
-  Returns the Floating Point resulted from decode the XDR value and its remaining bits
+  Decode the Floating-Point in XDR format to a `XDR.Float` structure.
+  If the binaries are not valid, an exception is raised.
   """
-  @spec decode_xdr!(bytes :: binary, opts :: any) :: {t(), binary()}
-  def decode_xdr!(bytes, opts \\ nil)
+  @spec decode_xdr!(bytes :: binary, float :: t) :: {t, binary}
+  def decode_xdr!(bytes, float \\ nil)
 
-  def decode_xdr!(bytes, opts) do
-    case decode_xdr(bytes, opts) do
+  def decode_xdr!(bytes, float) do
+    case decode_xdr(bytes, float) do
       {:ok, result} -> result
-      {:error, reason} -> raise(Float, reason)
+      {:error, reason} -> raise(FloatError, reason)
     end
   end
 end

--- a/lib/xdr/hyper_uint.ex
+++ b/lib/xdr/hyper_uint.ex
@@ -1,35 +1,31 @@
 defmodule XDR.HyperUInt do
-  @behaviour XDR.Declaration
   @moduledoc """
-  This module is in charge of process the Hyper Unsigned Integer types based on the RFC4506 XDR Standard
+  This module manages the `Unsigned Hyper Integer` type based on the RFC4506 XDR Standard.
   """
 
-  defstruct datum: nil
+  @behaviour XDR.Declaration
+
+  alias XDR.Error.HyperUInt, as: HyperUIntError
+
+  defstruct [:datum]
 
   @typedoc """
-  Every integer structure has a datum which represent the integer value which you try to encode
+  `XDR.HyperUInt` structure type specification.
   """
   @type t :: %XDR.HyperUInt{datum: integer | binary}
 
-  alias XDR.Error.HyperUInt
-
   @doc """
-  this function provides an easy way to create an XDR.HyperUInt type
-
-  returns a XDR.HyperInt struct with the value received as parameter
+  Create a new `XDR.HyperUInt` structure with the `opaque` and `length` passed.
   """
-  @spec new(datum :: integer | binary) :: t()
+  @spec new(datum :: integer | binary) :: t
   def new(datum), do: %XDR.HyperUInt{datum: datum}
 
   @impl XDR.Declaration
   @doc """
-  This function is in charge of encoding the Hyper Unsigned Integer received by parameter if the parameters
-  are wrong an error will be raised, it recieves an XDR.HyperUInt structure which contains the hyper int
-
-  Returns a tuple with the XDR resulted from encoding the Hyper Unsigned Integer value
+  Encode a `XDR.HyperUInt` structure into a XDR format.
   """
-  @spec encode_xdr(t()) ::
-          {:ok, binary()} | {:error, :not_integer | :exceed_upper_limit | :exceed_lower_limit}
+  @spec encode_xdr(h_uint :: t) ::
+          {:ok, binary} | {:error, :not_integer | :exceed_upper_limit | :exceed_lower_limit}
   def encode_xdr(%XDR.HyperUInt{datum: datum}) when not is_integer(datum),
     do: {:error, :not_integer}
 
@@ -44,54 +40,42 @@ defmodule XDR.HyperUInt do
 
   @impl XDR.Declaration
   @doc """
-  This function is in charge of encoding the Hyper Unsigned Integer received by parameter if the parameters
-  are wrong an error will be raised, it recieves an XDR.HyperUInt structure which contains the hyper int
-
-  Returns the XDR resulted from encoding the Hyper Unsigned Integer value
+  Encode a `XDR.HyperUInt` structure into a XDR format.
+  If the `h_uint` is not valid, an exception is raised.
   """
-  @spec encode_xdr!(t()) :: binary()
-  def encode_xdr!(datum) do
-    case encode_xdr(datum) do
+  @spec encode_xdr!(h_uint :: t) :: binary
+  def encode_xdr!(h_uint) do
+    case encode_xdr(h_uint) do
       {:ok, binary} -> binary
-      {:error, reason} -> raise(HyperUInt, reason)
+      {:error, reason} -> raise(HyperUIntError, reason)
     end
   end
 
   @impl XDR.Declaration
   @doc """
-  This function is in charge of decode the XDR value which represents an Hyper Unsigned Integer value if the parameters are wrong
-  an error will be raised, it recieves an XDR.HyperUInt structure which contains the binary value
-
-  Returns a tuple with the Hyper Unsigned Integer resulted from decode the XDR value and its remaining bits
+  Decode the Unsigned Hyper Integer in XDR format to a `XDR.HyperUInt` structure.
   """
-  @spec decode_xdr(bytes :: binary, opts :: any) :: {:ok, {t(), binary()}} | {:error, :not_binary}
-  def decode_xdr(bytes, opts \\ nil)
+  @spec decode_xdr(bytes :: binary, h_uint :: any) :: {:ok, {t, binary}} | {:error, :not_binary}
+  def decode_xdr(bytes, h_uint \\ nil)
 
-  def decode_xdr(bytes, _opts) when not is_binary(bytes),
+  def decode_xdr(bytes, _h_uint) when not is_binary(bytes),
     do: {:error, :not_binary}
 
-  def decode_xdr(bytes, _opts) do
-    <<hyper_uint::big-unsigned-integer-size(64), rest::binary>> = bytes
-
-    decoded_hyper_uint = new(hyper_uint)
-
-    {:ok, {decoded_hyper_uint, rest}}
-  end
+  def decode_xdr(<<hyper_uint::big-unsigned-integer-size(64), rest::binary>>, _h_uint),
+    do: {:ok, {new(hyper_uint), rest}}
 
   @impl XDR.Declaration
   @doc """
-  This function is in charge of decode the XDR value which represents an Hyper Unsigned Integer value if the parameters are wrong
-  an error will be raised, it recieves an XDR.HyperUInt structure which contains the binary value
-
-  Returns the Hyper Unsigned Integer resulted from decode the XDR value and its remaining bits
+  Decode the Unsigned Hyper Integer in XDR format to a `XDR.HyperUInt` structure.
+  If the binaries are not valid, an exception is raised.
   """
-  @spec decode_xdr!(bytes :: binary, opts :: any) :: {t(), binary()}
-  def decode_xdr!(bytes, opts \\ nil)
+  @spec decode_xdr!(bytes :: binary, h_uint :: any) :: {t, binary}
+  def decode_xdr!(bytes, h_uint \\ nil)
 
-  def decode_xdr!(bytes, opts) do
-    case decode_xdr(bytes, opts) do
+  def decode_xdr!(bytes, h_uint) do
+    case decode_xdr(bytes, h_uint) do
       {:ok, result} -> result
-      {:error, reason} -> raise(HyperUInt, reason)
+      {:error, reason} -> raise(HyperUIntError, reason)
     end
   end
 end

--- a/lib/xdr/optional.ex
+++ b/lib/xdr/optional.ex
@@ -1,73 +1,64 @@
 defmodule XDR.Optional do
-  @behaviour XDR.Declaration
   @moduledoc """
-  This module is in charge of process the Optional data types based on the RFC4506 XDR Standard
+  This module manages the `Optional-Data` type based on the RFC4506 XDR Standard.
   """
-  alias XDR.Bool
-  alias XDR.Error.Optional
 
-  defstruct type: nil
+  @behaviour XDR.Declaration
+
+  alias XDR.Bool
+  alias XDR.Error.Optional, as: OptionalError
+
+  defstruct [:type]
 
   @typedoc """
-  Every optional type contains the type of the data to process
+  `XDR.Optional` structure type specification.
   """
-  @type t :: %XDR.Optional{type: nil | any}
+  @type t :: %XDR.Optional{type: nil | any()}
 
   @doc """
-  This function provides an easy way to create a new Optional type
+  Create a new `XDR.Optional` structure with the `type` passed.
   """
-  @spec new(any) :: nil | t()
+  @spec new(type :: any()) :: t
   def new(type), do: %XDR.Optional{type: type}
 
   @impl XDR.Declaration
   @doc """
-  Encode Optional types
-
-  returns an :ok tuple with the encoded XDR
+  Encode a `XDR.Optional` structure into a XDR format.
   """
-  @spec encode_xdr(t()) :: {:ok, binary} | {:error, :not_valid}
+  @spec encode_xdr(optional :: t) :: {:ok, binary} | {:error, :not_valid}
   def encode_xdr(%{type: type}) when is_bitstring(type), do: {:error, :not_valid}
   def encode_xdr(%{type: type}) when is_list(type), do: {:error, :not_valid}
   def encode_xdr(%{type: type}) when is_tuple(type), do: {:error, :not_valid}
   def encode_xdr(%{type: type}) when is_boolean(type), do: {:error, :not_valid}
-
-  def encode_xdr(%{type: type}) when is_nil(type) do
-    Bool.new(false) |> Bool.encode_xdr()
-  end
+  def encode_xdr(%{type: nil}), do: false |> Bool.new() |> Bool.encode_xdr()
 
   def encode_xdr(%{type: type}) do
     module = type.__struct__
-
     encoded_value = module.encode_xdr!(type)
-
-    bool = Bool.new(true) |> Bool.encode_xdr!()
-
+    bool = true |> Bool.new() |> Bool.encode_xdr!()
     {:ok, bool <> encoded_value}
   end
 
   @impl XDR.Declaration
   @doc """
-  Encode Optional types
-
-  returns the encoded XDR
+  Encode a `XDR.Optional` structure into a XDR format.
+  If the `optional` is not valid, an exception is raised.
   """
-  @spec encode_xdr!(t()) :: binary
+  @spec encode_xdr!(optional :: t) :: binary
   def encode_xdr!(optional) do
     case encode_xdr(optional) do
       {:ok, binary} -> binary
-      {:error, reason} -> raise(Optional, reason)
+      {:error, reason} -> raise(OptionalError, reason)
     end
   end
 
   @impl XDR.Declaration
   @doc """
-  Decode Optional types
-
-  returns an :ok tuple with the decoded type
+  Decode the Optional-Data in XDR format to a `XDR.Optional` structure.
   """
-  @spec decode_xdr(bytes :: binary(), struct :: map()) ::
+  @spec decode_xdr(bytes :: binary(), optional :: t | map()) ::
           {:ok, {t, binary()}} | {:error, :not_binary | :not_module}
-  def decode_xdr(bytes, _struct) when not is_binary(bytes), do: {:error, :not_binary}
+  def decode_xdr(bytes, _optional) when not is_binary(bytes), do: {:error, :not_binary}
   def decode_xdr(_bytes, %{type: type}) when not is_atom(type), do: {:error, :not_module}
 
   def decode_xdr(bytes, %{type: type}) do
@@ -77,23 +68,21 @@ defmodule XDR.Optional do
 
   @impl XDR.Declaration
   @doc """
-  Decode Optional types
-
-  returns the decoded type
+  Decode the Optional-Data in XDR format to a `XDR.Optional` structure.
+  If the binaries are not valid, an exception is raised.
   """
-  @spec decode_xdr!(bytes :: binary(), struct :: map()) :: {t, binary()}
-  def decode_xdr!(bytes, struct) do
-    case decode_xdr(bytes, struct) do
+  @spec decode_xdr!(bytes :: binary(), optional :: t | map()) :: {t, binary()}
+  def decode_xdr!(bytes, optional) do
+    case decode_xdr(bytes, optional) do
       {:ok, result} -> result
-      {:error, reason} -> raise(Optional, reason)
+      {:error, reason} -> raise(OptionalError, reason)
     end
   end
 
-  @spec get_decoded_value(boolean(), rest :: binary(), type :: atom()) ::
+  @spec get_decoded_value(has_optional_value :: boolean(), rest :: binary(), type :: atom()) ::
           {:ok, {t, binary()}} | {:ok, {nil, binary()}}
   defp get_decoded_value(true, rest, type) do
     {decoded_type, rest} = type.decode_xdr!(rest)
-
     optional = new(decoded_type)
     {:ok, {optional, rest}}
   end

--- a/lib/xdr/quad_float.ex
+++ b/lib/xdr/quad_float.ex
@@ -1,8 +1,9 @@
 defmodule XDR.QuadFloat do
-  @behaviour XDR.Declaration
   @moduledoc """
   This module is not supported by the actual byte size
   """
+
+  @behaviour XDR.Declaration
 
   @impl XDR.Declaration
   @doc """

--- a/lib/xdr/string.ex
+++ b/lib/xdr/string.ex
@@ -1,35 +1,32 @@
 defmodule XDR.String do
-  @behaviour XDR.Declaration
   @moduledoc """
-  this module is in charge of process the  String types based on the RFC4506 XDR Standard
+  This module manages the `String` type based on the RFC4506 XDR Standard.
   """
 
-  defstruct string: nil, max_length: nil
-
-  @typedoc """
-  Every String structure has a String which represent the value which you try to encode
-  """
-  @type t :: %XDR.String{string: String.t() | binary(), max_length: integer}
+  @behaviour XDR.Declaration
 
   alias XDR.VariableOpaque
-  alias XDR.Error.String, as: StringErr
+  alias XDR.Error.String, as: StringError
+
+  defstruct [:string, :max_length]
+
+  @typedoc """
+  `XDR.String` structure type specification.
+  """
+  @type t :: %XDR.String{string: binary(), max_length: integer}
 
   @doc """
-  this function provides an easy way to create an XDR.String type
-
-  returns a XDR.String struct with the value received as parameter
+  Create a new `XDR.String` structure with the `opaque` and `length` passed.
   """
-  @spec new(string :: bitstring(), max_length :: integer()) :: t()
+  @spec new(string :: bitstring(), max_length :: integer()) :: t
   def new(string, max_length \\ 4_294_967_295)
   def new(string, max_length), do: %XDR.String{string: string, max_length: max_length}
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encode an string into an XDR format,it receives an XDR.String which contains the value to encode
-
-  returns an :ok tuple with the resulted XDR
+  Encode a `XDR.String` structure into a XDR format.
   """
-  @spec encode_xdr(map()) :: {:ok, binary} | {:error, :not_bitstring}
+  @spec encode_xdr(string :: t) :: {:ok, binary} | {:error, :not_bitstring}
   def encode_xdr(%{string: string}) when not is_bitstring(string),
     do: {:error, :not_bitstring}
 
@@ -45,28 +42,25 @@ defmodule XDR.String do
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encode an string into an XDR format,it receives an XDR.String which contains the value to encode
-
-  returns the resulted XDR
+  Encode a `XDR.String` structure into a XDR format.
+  If the `string` is not valid, an exception is raised.
   """
-  @spec encode_xdr!(map()) :: binary
+  @spec encode_xdr!(string :: t) :: binary
   def encode_xdr!(string) do
     case encode_xdr(string) do
       {:ok, binary} -> binary
-      {:error, reason} -> raise(StringErr, reason)
+      {:error, reason} -> raise(StringError, reason)
     end
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decode an XDR into a string, it receives and XDR.String structure which contains the binary to encode
-
-  returns an :ok tuple with the resulted string
+  Decode the String in XDR format to a `XDR.String` structure.
   """
-  @spec decode_xdr(bytes :: binary, struct :: map() | any) ::
-          {:ok, {t(), binary()}} | {:error, :not_binary}
-  def decode_xdr(bytes, struct \\ %{max_length: 4_294_967_295})
-  def decode_xdr(bytes, _struct) when not is_binary(bytes), do: {:error, :not_binary}
+  @spec decode_xdr(bytes :: binary, string :: t | map()) ::
+          {:ok, {t, binary()}} | {:error, :not_binary}
+  def decode_xdr(bytes, string \\ %{max_length: 4_294_967_295})
+  def decode_xdr(bytes, _string) when not is_binary(bytes), do: {:error, :not_binary}
 
   def decode_xdr(bytes, %{max_length: max_length}) do
     variable_struct = VariableOpaque.new(nil, max_length)
@@ -85,17 +79,16 @@ defmodule XDR.String do
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decode an XDR into a string, it receives and XDR.String structure which contains the binary to encode
-
-  returns the resulted string
+  Decode the String in XDR format to a `XDR.String` structure.
+  If the binaries are not valid, an exception is raised.
   """
-  @spec decode_xdr!(bytes :: binary, struct :: map() | any) :: {t(), binary()}
-  def decode_xdr!(bytes, struct \\ %{max_length: 4_294_967_295})
+  @spec decode_xdr!(bytes :: binary, string :: t | map()) :: {t, binary()}
+  def decode_xdr!(bytes, string \\ %{max_length: 4_294_967_295})
 
-  def decode_xdr!(bytes, struct) do
-    case decode_xdr(bytes, struct) do
+  def decode_xdr!(bytes, string) do
+    case decode_xdr(bytes, string) do
       {:ok, result} -> result
-      {:error, reason} -> raise(StringErr, reason)
+      {:error, reason} -> raise(StringError, reason)
     end
   end
 end

--- a/lib/xdr/union.ex
+++ b/lib/xdr/union.ex
@@ -1,26 +1,30 @@
 defmodule XDR.Union do
-  @behaviour XDR.Declaration
   @moduledoc """
-  this module is in charge of process the Discriminated Union types based on the RFC4506 XDR Standard
+  This module manages the `Discriminated Union` type based on the RFC4506 XDR Standard.
   """
 
-  defstruct discriminant: nil, arms: nil, value: nil
+  @behaviour XDR.Declaration
 
+  alias XDR.Error.Union, as: UnionError
+
+  defstruct [:discriminant, :arms, :value]
+
+  @typedoc """
+  `XDR.Union` structure type specification.
+  """
   @type t :: %XDR.Union{discriminant: XDR.Enum | XDR.Int | XDR.UInt, arms: list}
 
-  alias XDR.Error.Union
-
+  @doc """
+  Create a new `XDR.Union` structure with the `discriminant`, `arms` and `value` passed.
+  """
   def new(discriminant, arms, value \\ nil),
     do: %XDR.Union{discriminant: discriminant, arms: arms, value: value}
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encoding the Discriminated Union types, it receives a struct which contains the discriminant
-  which is the principal value to make the Union, and the arms which are the possible values that can be taken by the discriminant
-
-  returns an ok tuple which contains the binary encoded of the union
+  Encode a `XDR.Union` structure into a XDR format.
   """
-  @spec encode_xdr(map()) :: {:ok, binary()} | {:error, :not_atom}
+  @spec encode_xdr(union :: t) :: {:ok, binary()} | {:error, :not_atom}
   def encode_xdr(%{discriminant: %{identifier: identifier}}) when not is_atom(identifier),
     do: {:error, :not_atom}
 
@@ -46,40 +50,24 @@ defmodule XDR.Union do
     {:ok, encoded_discriminant <> encoded_arm}
   end
 
-  @spec encode_arm(arm :: struct() | module(), value :: any()) :: binary()
-  defp encode_arm(%_{} = arm, nil) do
-    arm_module = arm.__struct__
-    arm_module.encode_xdr!(arm)
-  end
-
-  defp encode_arm(arm, value) when is_atom(arm) do
-    arm.new(value) |> arm.encode_xdr!()
-  end
-
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encoding the Discriminated Union types, it receives a struct which contains the discriminant
-  which is the principal value to make the Union, and the arms which are the possible values that can be taken by the discriminant
-
-  returns the binary encoded of the union
+  Encode a `XDR.Union` structure into a XDR format.
+  If the `union` is not valid, an exception is raised.
   """
-  @spec encode_xdr!(map()) :: binary()
+  @spec encode_xdr!(union :: t) :: binary()
   def encode_xdr!(union) do
     case encode_xdr(union) do
       {:ok, binary} -> binary
-      {:error, reason} -> raise(Union, reason)
+      {:error, reason} -> raise(UnionError, reason)
     end
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decoding the XDR which represents an Disxriminated Union type, it receives a struct which contains the discriminant
-  which is the principal value to make the Union, and the arms which are the possible values that can be taken by the discriminant, and the specific
-  struct
-
-  returns an ok tuple which contains the values of the union
+  Decode the Discriminated Union in XDR format to a `XDR.Union` structure.
   """
-  @spec decode_xdr(bytes :: binary(), union :: map()) ::
+  @spec decode_xdr(bytes :: binary(), union :: t | map()) ::
           {:ok, {any, binary()}} | {:error, :not_binary | :not_list}
   def decode_xdr(bytes, union) do
     decode_union_discriminant(bytes, union)
@@ -88,17 +76,14 @@ defmodule XDR.Union do
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decoding the XDR which represents an Disxriminated Union type, it receives a struct which contains the discriminant
-  which is the principal value to make the Union, and the arms which are the possible values that can be taken by the discriminant, and the specific
-  struct
-
-  returns the values of the union
+  Decode the Discriminated Union in XDR format to a `XDR.Union` structure.
+  If the binaries are not valid, an exception is raised.
   """
-  @spec decode_xdr!(bytes :: binary(), union :: map()) :: {any, binary()}
+  @spec decode_xdr!(bytes :: binary(), union :: t | map()) :: {any, binary()}
   def decode_xdr!(bytes, union) do
     case decode_xdr(bytes, union) do
       {:ok, result} -> result
-      {:error, reason} -> raise(Union, reason)
+      {:error, reason} -> raise(UnionError, reason)
     end
   end
 
@@ -127,10 +112,18 @@ defmodule XDR.Union do
 
   defp decode_union_discriminant(bytes, %{discriminant: discriminant} = union) do
     discriminant_module = discriminant.__struct__
-
     {%{datum: datum}, rest} = discriminant_module.decode_xdr!(bytes)
-
     {%{union | discriminant: datum}, rest}
+  end
+
+  @spec encode_arm(arm :: struct() | module(), value :: any()) :: binary()
+  defp encode_arm(%_{} = arm, nil) do
+    arm_module = arm.__struct__
+    arm_module.encode_xdr!(arm)
+  end
+
+  defp encode_arm(arm, value) when is_atom(arm) do
+    arm.new(value) |> arm.encode_xdr!()
   end
 
   @spec decode_union_arm({:error, atom}) :: {:error, atom}
@@ -139,9 +132,7 @@ defmodule XDR.Union do
   @spec decode_union_arm({map(), binary}) :: {:ok, {{atom | integer, any}, binary}}
   defp decode_union_arm({%{discriminant: discriminant, arms: arms}, rest}) do
     arm_module = arms[discriminant] |> get_arm_module()
-
     {decoded_arm, rest} = arm_module.decode_xdr!(rest)
-
     {:ok, {{discriminant, decoded_arm}, rest}}
   end
 

--- a/lib/xdr/variable_array.ex
+++ b/lib/xdr/variable_array.ex
@@ -1,38 +1,37 @@
 defmodule XDR.VariableArray do
-  @behaviour XDR.Declaration
   @moduledoc """
-  this module is in charge of process the variable array types based on the RFC4506 XDR Standard
+  This module manages the `Variable-Length Array` type based on the RFC4506 XDR Standard.
   """
 
-  defstruct elements: nil, type: nil, max_length: nil
+  @behaviour XDR.Declaration
 
-  @typedoc """
-  Every VariableArray structure has the list of elements to encode, the type of these elements and the max_length of the list
-  """
-  @type t :: %XDR.VariableArray{elements: list | binary, type: module, max_length: integer}
-
-  alias XDR.Error.VariableArray
+  alias XDR.Error.VariableArray, as: VariableArrayError
   alias XDR.{UInt, FixedArray}
 
-  @doc """
-  this function provides an easy way to create an XDR.VariableArray type, it receives an XDR.VariableArray structure which contains the
-  data needed to encode the Variable Array
+  defstruct [:elements, :type, :max_length]
 
-  returns a XDR.VariableArray struct with the value received as parameter
+  @typedoc """
+  `XDR.VariableArray` structure type specification.
   """
-  @spec new(elements :: list | binary, type :: module, max_length :: integer) :: t()
+  @type t :: %XDR.VariableArray{
+          elements: list() | binary(),
+          type: module(),
+          max_length: integer()
+        }
+
+  @doc """
+  Create a new `XDR.VariableArray` structure with the `elements`, `type` and `max_length` passed.
+  """
+  @spec new(elements :: list() | binary(), type :: module(), max_length :: integer()) :: t
   def new(elements, type, max_length),
     do: %XDR.VariableArray{elements: elements, type: type, max_length: max_length}
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encode a Variable Array into an XDR, it receives an XDR.VariableArray structure which
-  contains the data needed to encode the variable array
-
-  returns an :ok tuple with the resulted XDR
+  Encode a `XDR.VariableArray` structure into a XDR format.
   """
-  @spec encode_xdr(map()) ::
-          {:ok, binary}
+  @spec encode_xdr(variable_array :: t) ::
+          {:ok, binary()}
           | {:error,
              :not_number
              | :exceed_lower_bound
@@ -56,42 +55,30 @@ defmodule XDR.VariableArray do
 
   def encode_xdr(%{elements: elements, type: type}) do
     array_length = length(elements)
-
-    encoded_length =
-      UInt.new(array_length)
-      |> UInt.encode_xdr!()
-
-    encoded_array =
-      FixedArray.new(elements, type, array_length)
-      |> FixedArray.encode_xdr!()
-
+    encoded_length = array_length |> UInt.new() |> UInt.encode_xdr!()
+    encoded_array = FixedArray.new(elements, type, array_length) |> FixedArray.encode_xdr!()
     {:ok, encoded_length <> encoded_array}
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encode a Variable Array into an XDR, it receives an XDR.VariableArray structure which
-  contains the data needed to encode the variable array
-
-  returns the resulted XDR
+  Encode a `XDR.VariableArray` structure into a XDR format.
+  If the `variable_array` is not valid, an exception is raised.
   """
-  @spec encode_xdr!(map()) :: binary
+  @spec encode_xdr!(variable_array :: t) :: binary()
   def encode_xdr!(variable_array) do
     case encode_xdr(variable_array) do
       {:ok, binary} -> binary
-      {:error, reason} -> raise(VariableArray, reason)
+      {:error, reason} -> raise(VariableArrayError, reason)
     end
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decode an XDR into a Variable Array, it receives an XDR.VariableArray structure which
-  contains the data needed to decode the binary
-
-  returns an :ok tuple with the resulted array
+  Decode the Variable-Length Array in XDR format to a `XDR.VariableArray` structure.
   """
-  @spec decode_xdr(bytes :: binary, struct :: map()) ::
-          {:ok, {list, binary}}
+  @spec decode_xdr(bytes :: binary, struct :: t) ::
+          {:ok, {list(), binary()}}
           | {:error,
              :not_number
              | :exceed_lower_bound
@@ -99,20 +86,18 @@ defmodule XDR.VariableArray do
              | :invalid_length
              | :invalid_binary
              | :not_binary}
-  def decode_xdr(_bytes, %{max_length: max_length})
-      when not is_integer(max_length),
-      do: {:error, :not_number}
+  def decode_xdr(_bytes, %{max_length: max_length}) when not is_integer(max_length),
+    do: {:error, :not_number}
 
   def decode_xdr(_bytes, %{max_length: max_length}) when max_length <= 0,
     do: {:error, :exceed_lower_bound}
 
-  def decode_xdr(_bytes, %{max_length: max_length})
-      when max_length > 4_294_967_295,
-      do: {:error, :exceed_upper_bound}
+  def decode_xdr(_bytes, %{max_length: max_length}) when max_length > 4_294_967_295,
+    do: {:error, :exceed_upper_bound}
 
-  def decode_xdr(<<xdr_len::big-unsigned-integer-size(32), _::binary>>, %{
-        max_length: max_length
-      })
+  def decode_xdr(bytes, _struct) when not is_binary(bytes), do: {:error, :not_binary}
+
+  def decode_xdr(<<xdr_len::big-unsigned-integer-size(32), _::binary>>, %{max_length: max_length})
       when xdr_len > max_length,
       do: {:error, :invalid_length}
 
@@ -120,31 +105,25 @@ defmodule XDR.VariableArray do
       when xdr_len * 4 > byte_size(rest),
       do: {:error, :invalid_binary}
 
-  def decode_xdr(bytes, _struct) when not is_binary(bytes),
-    do: {:error, :not_binary}
-
   def decode_xdr(bytes, %{type: type}) do
     {array_length, rest} = UInt.decode_xdr!(bytes)
 
     fixed_array =
-      rest
-      |> FixedArray.decode_xdr!(%XDR.FixedArray{type: type, length: array_length.datum})
+      FixedArray.decode_xdr!(rest, %XDR.FixedArray{type: type, length: array_length.datum})
 
     {:ok, fixed_array}
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decode an XDR into a Variable Array, it receives an XDR.VariableArray structure which
-  contains the data needed to decode the binary
-
-  returns the resulted array
+  Decode the Variable-Length Array in XDR format to a `XDR.VariableArray` structure.
+  If the binaries are not valid, an exception is raised.
   """
   @spec decode_xdr!(bytes :: binary, struct :: map()) :: {list, binary}
   def decode_xdr!(bytes, struct) do
     case decode_xdr(bytes, struct) do
       {:ok, result} -> result
-      {:error, reason} -> raise(VariableArray, reason)
+      {:error, reason} -> raise(VariableArrayError, reason)
     end
   end
 end

--- a/lib/xdr/variable_opaque.ex
+++ b/lib/xdr/variable_opaque.ex
@@ -1,36 +1,32 @@
 defmodule XDR.VariableOpaque do
-  @behaviour XDR.Declaration
   @moduledoc """
-  This module is in charge of process the Variable length opaque based on the RFC4506 XDR Standard
+  This module manages the `Variable-Length Opaque Data` type based on the RFC4506 XDR Standard.
   """
 
-  defstruct opaque: nil, max_size: nil
+  @behaviour XDR.Declaration
+
+  alias XDR.{FixedOpaque, UInt}
+  alias XDR.Error.VariableOpaque, as: VariableOpaqueError
+
+  defstruct [:opaque, :max_size]
 
   @typedoc """
-  Every double float structure has a float which represent the Double-Precision Floating-Point value which you try to encode
+  `XDR.VariableOpaque` structure type specification.
   """
   @type t :: %XDR.VariableOpaque{opaque: binary() | nil, max_size: integer()}
 
-  alias XDR.{FixedOpaque, UInt}
-  alias XDR.Error.VariableOpaque, as: VariableOpaqueErr
-
   @doc """
-  this function provides an easy way to create an XDR.VariableOpaque type
-
-  returns a XDR.VariableOpaque struct with the value received as parameter
+  Create a new `XDR.VariableOpaque` structure with the `opaque` and `max_size` passed.
   """
-  @spec new(opaque :: binary | nil, max_size :: integer) :: t()
+  @spec new(opaque :: binary | nil, max_size :: integer) :: t
   def new(opaque, max_size \\ 4_294_967_295)
   def new(opaque, max_size), do: %XDR.VariableOpaque{opaque: opaque, max_size: max_size}
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encode the variable length opaque into an XDR,it receives an XDR.VariableOpaque stucture
-  which contains the needed data to encode the opaque
-
-  returns an :ok tuple with the resulted XDR
+  Encode a `XDR.VariableOpaque` structure into a XDR format.
   """
-  @spec encode_xdr(map()) ::
+  @spec encode_xdr(opaque :: t) ::
           {:ok, binary}
           | {:error,
              :not_binary
@@ -56,42 +52,29 @@ defmodule XDR.VariableOpaque do
 
   def encode_xdr(%{opaque: opaque}) do
     length = byte_size(opaque)
-
-    opaque_length =
-      length
-      |> UInt.new()
-      |> UInt.encode_xdr!()
-
-    fixed_opaque =
-      FixedOpaque.new(opaque, length)
-      |> FixedOpaque.encode_xdr!()
-
+    opaque_length = length |> UInt.new() |> UInt.encode_xdr!()
+    fixed_opaque = FixedOpaque.new(opaque, length) |> FixedOpaque.encode_xdr!()
     {:ok, opaque_length <> fixed_opaque}
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encode the variable length opaque into an XDR,it receives an XDR.VariableOpaque stucture
-  which contains the needed data to encode the opaque
-
-  returns the resulted XDR
+  Encode a `XDR.VariableOpaque` structure into a XDR format.
+  If the `opaque` is not valid, an exception is raised.
   """
-  @spec encode_xdr!(map()) :: binary
+  @spec encode_xdr!(opaque :: t) :: binary()
   def encode_xdr!(opaque) do
     case encode_xdr(opaque) do
       {:ok, binary} -> binary
-      {:error, reason} -> raise(VariableOpaqueErr, reason)
+      {:error, reason} -> raise(VariableOpaqueError, reason)
     end
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decode the XDR into a variable length opaque,it receives an XDR.VariableOpaque stucture
-  which contains the needed data to decode the opaque
-
-  returns an :ok tuple with the resulted binary
+  Decode the Variable-Length Opaque Data in XDR format to a `XDR.VariableOpaque` structure.
   """
-  @spec decode_xdr(bytes :: binary, opts :: map()) ::
+  @spec decode_xdr(bytes :: binary, opaque :: t) ::
           {:ok, {t, binary}}
           | {:error,
              :not_binary
@@ -100,9 +83,9 @@ defmodule XDR.VariableOpaque do
              | :exceed_upper_bound
              | :length_over_max
              | :length_over_rest}
-  def decode_xdr(bytes, opts \\ %{max_size: 4_294_967_295})
+  def decode_xdr(bytes, opaque \\ %{max_size: 4_294_967_295})
 
-  def decode_xdr(bytes, _opts) when not is_binary(bytes),
+  def decode_xdr(bytes, _opaque) when not is_binary(bytes),
     do: {:error, :not_binary}
 
   def decode_xdr(_bytes, %{max_size: max_size}) when not is_integer(max_size),
@@ -116,41 +99,34 @@ defmodule XDR.VariableOpaque do
 
   def decode_xdr(bytes, %{max_size: max_size}) do
     {uint, rest} = UInt.decode_xdr!(bytes)
-
-    get_decoded_value({uint.datum, rest}, max_size)
+    uint.datum |> get_decoded_value(rest, max_size)
   end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decode the XDR into a variable length opaque,it receives an XDR.VariableOpaque stucture
-  which contains the needed data to decode the opaque
-
-  returns an :ok tuple with the resulted binary
+  Decode the Variable-Length Opaque Data in XDR format to a `XDR.VariableOpaque` structure.
+  If the binaries are not valid, an exception is raised.
   """
-  @spec decode_xdr!(bytes :: binary, opts :: map()) :: {t, binary}
-  def decode_xdr!(bytes, struct \\ %{max_size: 4_294_967_295})
+  @spec decode_xdr!(bytes :: binary, opaque :: t) :: {t, binary}
+  def decode_xdr!(bytes, opaque \\ %{max_size: 4_294_967_295})
 
-  def decode_xdr!(bytes, struct) do
-    case decode_xdr(bytes, struct) do
+  def decode_xdr!(bytes, opaque) do
+    case decode_xdr(bytes, opaque) do
       {:ok, result} -> result
-      {:error, reason} -> raise(VariableOpaqueErr, reason)
+      {:error, reason} -> raise(VariableOpaqueError, reason)
     end
   end
 
-  @spec get_decoded_value({integer(), binary()}, max :: integer()) :: {:ok, {t, binary}}
-  defp get_decoded_value({length, _rest}, max) when length > max,
-    do: {:error, :length_over_max}
+  @spec get_decoded_value(length :: integer(), rest :: binary(), max :: integer()) ::
+          {:ok, {t, binary}}
+  defp get_decoded_value(length, _rest, max) when length > max, do: {:error, :length_over_max}
 
-  defp get_decoded_value({length, rest}, _max) when length > byte_size(rest),
+  defp get_decoded_value(length, rest, _max) when length > byte_size(rest),
     do: {:error, :length_over_rest}
 
-  defp get_decoded_value({length, rest}, max) do
+  defp get_decoded_value(length, rest, max) do
     {fixed_opaque, rest} = FixedOpaque.decode_xdr!(rest, %XDR.FixedOpaque{length: length})
-
-    decoded_variable_array =
-      fixed_opaque.opaque
-      |> new(max)
-
+    decoded_variable_array = fixed_opaque.opaque |> new(max)
     {:ok, {decoded_variable_array, rest}}
   end
 end

--- a/lib/xdr/void.ex
+++ b/lib/xdr/void.ex
@@ -52,6 +52,7 @@ defmodule XDR.Void do
   """
   @spec decode_xdr(binary, any) :: {:ok, {nil, binary}} | {:error, :not_void}
   def decode_xdr(<<>>, _), do: {:ok, {nil, ""}}
+  def decode_xdr(<<rest::binary>>, _), do: {:ok, {nil, rest}}
   def decode_xdr(_, _), do: {:error, :not_void}
   @impl XDR.Declaration
   @doc """
@@ -63,5 +64,6 @@ defmodule XDR.Void do
   @spec decode_xdr!(binary, any) :: {nil, binary}
   def decode_xdr!(bytes, opts \\ nil)
   def decode_xdr!(<<>>, _), do: {nil, ""}
+  def decode_xdr!(<<rest::binary>>, _), do: {nil, rest}
   def decode_xdr!(_, _), do: raise(Void, :not_void)
 end

--- a/lib/xdr/void.ex
+++ b/lib/xdr/void.ex
@@ -1,69 +1,65 @@
 defmodule XDR.Void do
-  @behaviour XDR.Declaration
   @moduledoc """
-  This module is in charge of manage the Void types based on the RFC4506 XDR Standard
+  This module manages the `Void` type based on the RFC4506 XDR Standard.
   """
 
-  defstruct void: nil
+  @behaviour XDR.Declaration
+
+  alias XDR.Error.Void, as: VoidError
+
+  defstruct [:void]
 
   @typedoc """
-  the void type contains the value of the void it must be void or binary
+  `XDR.Void` struct type specification.
   """
-  @type t :: %XDR.Void{void: binary | nil}
-
-  alias XDR.Error.Void
+  @type t :: %XDR.Void{void: nil}
 
   @doc """
-  this function provides an easy way to create a new void type, it receives the value and create a new XDR.Void structure
-
-  returns an XDR.Void structure
+  Create a new `XDR.Void` structure from the `value` passed.
   """
-  @spec new(nil) :: t()
-  def new(value), do: %XDR.Void{void: value}
+  @spec new(value :: nil) :: t
+  def new(value \\ nil) when is_nil(value), do: %XDR.Void{}
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encoding the void values into an XDR format, it receives an XDR.Void structure which contains
-  the void value
-
-  returns and ok tuple with the resulted XDR
+  Encode a `XDR.Void` structure into a XDR format.
   """
-  @spec encode_xdr(t()) :: {:ok, binary} | {:error, :not_void}
+  @spec encode_xdr(void :: t) :: {:ok, binary} | {:error, :not_void}
   def encode_xdr(%XDR.Void{void: nil}), do: {:ok, <<>>}
   def encode_xdr(_), do: {:error, :not_void}
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of encoding the void values into an XDR format, it receives an XDR.Void structure which contains
-  the void value
-
-  returns the resulted XDR
+  Encode a `XDR.Void` structure into a XDR format.
+  If the structure received is not `XDR.Void`, an exception is raised.
   """
-  @spec encode_xdr!(t()) :: binary
-  def encode_xdr!(%XDR.Void{void: nil}), do: <<>>
-  def encode_xdr!(_), do: raise(Void, :not_void)
+  @spec encode_xdr!(void :: t) :: binary()
+  def encode_xdr!(void) do
+    case encode_xdr(void) do
+      {:ok, result} -> result
+      {:error, reason} -> raise(VoidError, reason)
+    end
+  end
 
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decoding the void values into an vo format, it receives an XDR.Void structure which contains
-  the void value
-
-  returns and ok tuple with the resulted void
+  Decode the XDR format to a void format.
   """
-  @spec decode_xdr(binary, any) :: {:ok, {nil, binary}} | {:error, :not_void}
-  def decode_xdr(<<>>, _), do: {:ok, {nil, ""}}
+  @spec decode_xdr(bytes :: binary(), void :: t) :: {:ok, {nil, binary}} | {:error, :not_binary}
+  def decode_xdr(bytes, _void \\ nil)
   def decode_xdr(<<rest::binary>>, _), do: {:ok, {nil, rest}}
-  def decode_xdr(_, _), do: {:error, :not_void}
+  def decode_xdr(_, _), do: {:error, :not_binary}
+
   @impl XDR.Declaration
   @doc """
-  this function is in charge of decoding the void values into an vo format, it receives an XDR.Void structure which contains
-  the void value
-
-  returns the resulted void
+  Decode the XDR format to a void format.
+  If the binary is not a valid void, an exception is raised.
   """
-  @spec decode_xdr!(binary, any) :: {nil, binary}
-  def decode_xdr!(bytes, opts \\ nil)
-  def decode_xdr!(<<>>, _), do: {nil, ""}
-  def decode_xdr!(<<rest::binary>>, _), do: {nil, rest}
-  def decode_xdr!(_, _), do: raise(Void, :not_void)
+  @spec decode_xdr!(bytes :: binary(), void :: t) :: {nil, binary}
+  def decode_xdr!(bytes, _void \\ nil) do
+    case decode_xdr(bytes) do
+      {:ok, result} -> result
+      {:error, reason} -> raise(VoidError, reason)
+    end
+  end
 end

--- a/test/xdr/bool_test.exs
+++ b/test/xdr/bool_test.exs
@@ -1,32 +1,30 @@
 defmodule XDR.BoolTest do
+  @moduledoc """
+  Tests for the `XDR.Bool` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.Bool
-  alias XDR.Error.Bool, as: BoolErr
+  alias XDR.Error.Bool, as: BoolError
 
   describe "Encoding Boolean structures" do
     test "when the value is not boolean" do
-      {status, reason} =
-        Bool.new("true")
-        |> Bool.encode_xdr()
+      {status, reason} = Bool.new("true") |> Bool.encode_xdr()
 
       assert status == :error
       assert reason == :not_boolean
     end
 
     test "with valid data" do
-      {status, result} =
-        Bool.new(false)
-        |> Bool.encode_xdr()
+      {status, result} = Bool.new(false) |> Bool.encode_xdr()
 
       assert status === :ok
       assert result === <<0, 0, 0, 0>>
     end
 
     test "encode_xdr! with valid data" do
-      result =
-        Bool.new(true)
-        |> Bool.encode_xdr!()
+      result = Bool.new(true) |> Bool.encode_xdr!()
 
       assert result === <<0, 0, 0, 1>>
     end
@@ -34,7 +32,7 @@ defmodule XDR.BoolTest do
     test "encode_xdr! when is not boolean" do
       bool = Bool.new("true")
 
-      assert_raise BoolErr, fn -> Bool.encode_xdr!(bool) end
+      assert_raise BoolError, fn -> Bool.encode_xdr!(bool) end
     end
   end
 
@@ -60,7 +58,7 @@ defmodule XDR.BoolTest do
     end
 
     test "decode_xdr! when is not binary value" do
-      assert_raise BoolErr, fn -> Bool.decode_xdr!(5860) end
+      assert_raise BoolError, fn -> Bool.decode_xdr!(5860) end
     end
   end
 end

--- a/test/xdr/double_float_test.exs
+++ b/test/xdr/double_float_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.DoubleFloatTest do
+  @moduledoc """
+  Tests for the `XDR.DoubleFloat` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.DoubleFloat
-  alias XDR.Error.DoubleFloat, as: DoubleFloatErr
+  alias XDR.Error.DoubleFloat, as: DoubleFloatError
 
   describe "defguard tests" do
     test "valid_float? guard" do
@@ -62,7 +66,7 @@ defmodule XDR.DoubleFloatTest do
     test "encode_xdr! when receives a String" do
       float = DoubleFloat.new("hello world")
 
-      assert_raise DoubleFloatErr, fn -> DoubleFloat.encode_xdr!(float) end
+      assert_raise DoubleFloatError, fn -> DoubleFloat.encode_xdr!(float) end
     end
 
     test "with negative integer" do
@@ -122,7 +126,7 @@ defmodule XDR.DoubleFloatTest do
     end
 
     test "decode_xdr! when is not binary value" do
-      assert_raise DoubleFloatErr, fn -> DoubleFloat.decode_xdr!(5860) end
+      assert_raise DoubleFloatError, fn -> DoubleFloat.decode_xdr!(5860) end
     end
   end
 end

--- a/test/xdr/enum_test.exs
+++ b/test/xdr/enum_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.EnumTest do
+  @moduledoc """
+  Tests for the `XDR.Enum` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.Enum
-  alias XDR.Error.Enum, as: EnumErr
+  alias XDR.Error.Enum, as: EnumError
 
   setup do
     keyword = [red: 0, blue: 1, yellow: 2]
@@ -58,7 +62,7 @@ defmodule XDR.EnumTest do
     test "encode_xdr! with invalid data", %{keyword: keyword} do
       enum = Enum.new(keyword, :purple)
 
-      assert_raise EnumErr, fn -> Enum.encode_xdr!(enum) end
+      assert_raise EnumError, fn -> Enum.encode_xdr!(enum) end
     end
   end
 
@@ -103,7 +107,7 @@ defmodule XDR.EnumTest do
     test "decode_xdr! with invalid key", %{keyword: keyword} do
       enum = %XDR.Enum{declarations: keyword}
 
-      assert_raise EnumErr, fn -> Enum.decode_xdr!(<<0, 0, 0, 3>>, enum) end
+      assert_raise EnumError, fn -> Enum.decode_xdr!(<<0, 0, 0, 3>>, enum) end
     end
   end
 end

--- a/test/xdr/fixed_array_test.exs
+++ b/test/xdr/fixed_array_test.exs
@@ -1,10 +1,23 @@
 defmodule XDR.FixedArrayTest do
+  @moduledoc """
+  Tests for the `XDR.FixedArray` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.FixedArray
-  alias XDR.Error.FixedArray, as: FixedArrayErr
+  alias XDR.Error.FixedArray, as: FixedArrayError
 
   describe "Encoding Fixed Array" do
+    test "with invalid type" do
+      {status, reason} =
+        FixedArray.new([0, 0, 1], "XDR.Int", 3)
+        |> FixedArray.encode_xdr()
+
+      assert status == :error
+      assert reason == :invalid_type
+    end
+
     test "when xdr is not list" do
       {status, reason} =
         FixedArray.new(<<0, 0, 1>>, XDR.Int, 3)
@@ -55,11 +68,19 @@ defmodule XDR.FixedArrayTest do
     test "encode_xdr! when length is not an integer" do
       fixed_array = FixedArray.new([0, 0, 1], XDR.Int, "3")
 
-      assert_raise FixedArrayErr, fn -> FixedArray.encode_xdr!(fixed_array) end
+      assert_raise FixedArrayError, fn -> FixedArray.encode_xdr!(fixed_array) end
     end
   end
 
   describe "Decoding Fixed Array" do
+    test "with invalid type" do
+      {status, result} =
+        FixedArray.decode_xdr(<<0, 0, 1, 0>>, %XDR.FixedArray{type: "XDR.Int", length: 1})
+
+      assert status == :error
+      assert result == :invalid_type
+    end
+
     test "when xdr is not binary" do
       {status, result} =
         FixedArray.decode_xdr([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1], %XDR.FixedArray{
@@ -108,7 +129,7 @@ defmodule XDR.FixedArrayTest do
     test "decode_xdr! with invalid data" do
       fixed_array = %XDR.FixedArray{type: XDR.Int, length: 1}
 
-      assert_raise FixedArrayErr, fn -> FixedArray.decode_xdr!(<<0, 0, 1>>, fixed_array) end
+      assert_raise FixedArrayError, fn -> FixedArray.decode_xdr!(<<0, 0, 1>>, fixed_array) end
     end
   end
 end

--- a/test/xdr/fixed_opaque_test.exs
+++ b/test/xdr/fixed_opaque_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.FixedOpaqueTest do
+  @moduledoc """
+  Tests for the `XDR.FixedOpaque` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.FixedOpaque
-  alias XDR.Error.FixedOpaque, as: FixedOpaqueErr
+  alias XDR.Error.FixedOpaque, as: FixedOpaqueError
 
   describe "Encoding Fixed Opaque" do
     test "when xdr is not binary" do
@@ -52,7 +56,7 @@ defmodule XDR.FixedOpaqueTest do
     test "encode_xdr! when length is not an integer" do
       fixed_opaque = FixedOpaque.new(<<0, 0, 1>>, "hi")
 
-      assert_raise FixedOpaqueErr, fn -> FixedOpaque.encode_xdr!(fixed_opaque) end
+      assert_raise FixedOpaqueError, fn -> FixedOpaque.encode_xdr!(fixed_opaque) end
     end
   end
 
@@ -98,7 +102,9 @@ defmodule XDR.FixedOpaqueTest do
     test "decode_xdr! when length is not an integer" do
       fixed_opaque = %XDR.FixedOpaque{length: "2"}
 
-      assert_raise FixedOpaqueErr, fn -> FixedOpaque.decode_xdr!(<<0, 0, 1, 0>>, fixed_opaque) end
+      assert_raise FixedOpaqueError, fn ->
+        FixedOpaque.decode_xdr!(<<0, 0, 1, 0>>, fixed_opaque)
+      end
     end
   end
 end

--- a/test/xdr/float_test.exs
+++ b/test/xdr/float_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.FloatTest do
+  @moduledoc """
+  Tests for the `XDR.Float` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.Float
-  alias XDR.Error.Float, as: FloatErr
+  alias XDR.Error.Float, as: FloatError
 
   describe "defguard tests" do
     test "valid_float? guard" do
@@ -62,7 +66,7 @@ defmodule XDR.FloatTest do
     test "encode_xdr! when receives an atom" do
       float = Float.new(:hello)
 
-      assert_raise FloatErr, fn -> Float.encode_xdr!(float) end
+      assert_raise FloatError, fn -> Float.encode_xdr!(float) end
     end
 
     test "with negative integer" do
@@ -126,7 +130,7 @@ defmodule XDR.FloatTest do
     test "decode_xdr! when is not binary value" do
       float = Float.new(5860)
 
-      assert_raise FloatErr, fn -> Float.decode_xdr!(float) end
+      assert_raise FloatError, fn -> Float.decode_xdr!(float) end
     end
   end
 end

--- a/test/xdr/hyper_int_test.exs
+++ b/test/xdr/hyper_int_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.HyperIntTest do
+  @moduledoc """
+  Tests for the `XDR.HyperInt` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.HyperInt
-  alias XDR.Error.HyperInt, as: HyperIntErr
+  alias XDR.Error.HyperInt, as: HyperIntError
 
   describe "Encoding Hyper Integer to binary" do
     test "when is not an integer value" do
@@ -52,7 +56,7 @@ defmodule XDR.HyperIntTest do
     test "encode_xdr! when is not an integer value" do
       hyper_int = HyperInt.new("hello world")
 
-      assert_raise HyperIntErr, fn -> HyperInt.encode_xdr!(hyper_int) end
+      assert_raise HyperIntError, fn -> HyperInt.encode_xdr!(hyper_int) end
     end
   end
 
@@ -89,7 +93,7 @@ defmodule XDR.HyperIntTest do
     test "decode_xdr! when is not binary value" do
       hyper_int = HyperInt.new(5860)
 
-      assert_raise HyperIntErr, fn -> HyperInt.decode_xdr!(hyper_int) end
+      assert_raise HyperIntError, fn -> HyperInt.decode_xdr!(hyper_int) end
     end
   end
 end

--- a/test/xdr/hyper_uint_test.exs
+++ b/test/xdr/hyper_uint_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.HyperUIntTest do
+  @moduledoc """
+  Tests for the `XDR.HyperUInt` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.HyperUInt
-  alias XDR.Error.HyperUInt, as: HyperUIntErr
+  alias XDR.Error.HyperUInt, as: HyperUIntError
 
   describe "Encoding Hyper Unsigned Integer to binary" do
     test "when is not an integer value" do
@@ -52,7 +56,7 @@ defmodule XDR.HyperUIntTest do
     test "encode_xdr! when is not an integer value" do
       hyper_uint = HyperUInt.new("hello world")
 
-      assert_raise HyperUIntErr, fn -> HyperUInt.encode_xdr!(hyper_uint) end
+      assert_raise HyperUIntError, fn -> HyperUInt.encode_xdr!(hyper_uint) end
     end
   end
 
@@ -84,7 +88,7 @@ defmodule XDR.HyperUIntTest do
     end
 
     test "decode_xdr!when is not binary value" do
-      assert_raise HyperUIntErr, fn -> HyperUInt.decode_xdr!(5860) end
+      assert_raise HyperUIntError, fn -> HyperUInt.decode_xdr!(5860) end
     end
   end
 end

--- a/test/xdr/int_test.exs
+++ b/test/xdr/int_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.IntTest do
+  @moduledoc """
+  Tests for the `XDR.Int` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.Int
-  alias XDR.Error.Int, as: IntErr
+  alias XDR.Error.Int, as: IntError
 
   describe "Encoding integer to binary" do
     test "when is not an integer value" do
@@ -52,7 +56,7 @@ defmodule XDR.IntTest do
     test "decode_xdr! when is not an integer value" do
       integer = Int.new("hello world")
 
-      assert_raise IntErr, fn -> Int.encode_xdr!(integer) end
+      assert_raise IntError, fn -> Int.encode_xdr!(integer) end
     end
   end
 
@@ -89,7 +93,7 @@ defmodule XDR.IntTest do
     test "decode_xdr! when is not binary value" do
       integer = Int.new(5860)
 
-      assert_raise IntErr, fn -> Int.decode_xdr!(integer) end
+      assert_raise IntError, fn -> Int.decode_xdr!(integer) end
     end
   end
 end

--- a/test/xdr/optional_test.exs
+++ b/test/xdr/optional_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.OptionalTest do
+  @moduledoc """
+  Tests for the `XDR.Optional` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.Optional
-  alias XDR.Error.Optional, as: OptionalErr
+  alias XDR.Error.Optional, as: OptionalError
 
   describe "Encoding Optional type to binary" do
     test "when receives a string" do
@@ -89,7 +93,7 @@ defmodule XDR.OptionalTest do
     test "encode_xdr! when receives a string" do
       optional = Optional.new("hello world")
 
-      assert_raise OptionalErr, fn -> Optional.encode_xdr!(optional) end
+      assert_raise OptionalError, fn -> Optional.encode_xdr!(optional) end
     end
   end
 
@@ -141,7 +145,7 @@ defmodule XDR.OptionalTest do
     end
 
     test "decode_xdr! when is not binary value" do
-      assert_raise OptionalErr, fn ->
+      assert_raise OptionalError, fn ->
         Optional.decode_xdr!([0, 0, 0, 1, 0, 0, 22, 228], %{type: XDR.Int})
       end
     end

--- a/test/xdr/quad_float_test.exs
+++ b/test/xdr/quad_float_test.exs
@@ -1,4 +1,8 @@
 defmodule XDR.QuadFloatTest do
+  @moduledoc """
+  Tests for the `XDR.QuadFloat` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.QuadFloat

--- a/test/xdr/string_test.exs
+++ b/test/xdr/string_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.StringTest do
+  @moduledoc """
+  Tests for the `XDR.String` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.String
-  alias XDR.Error.String, as: StringErr
+  alias XDR.Error.String, as: StringError
 
   describe "Encoding string to binary" do
     test "when is not a bitstring value" do
@@ -34,7 +38,7 @@ defmodule XDR.StringTest do
     test "encode_xdr! when is not a bitstring value" do
       string = String.new(2)
 
-      assert_raise StringErr, fn -> String.encode_xdr!(string) end
+      assert_raise StringError, fn -> String.encode_xdr!(string) end
     end
   end
 
@@ -64,7 +68,7 @@ defmodule XDR.StringTest do
 
     test "encode_xdr! when is not binary" do
       list = [0, 0, 0, 9, 107, 111, 109, 109, 105, 116, 46, 99, 111, 0, 0, 0]
-      assert_raise StringErr, fn -> String.decode_xdr!(list) end
+      assert_raise StringError, fn -> String.decode_xdr!(list) end
     end
   end
 end

--- a/test/xdr/struct_test.exs
+++ b/test/xdr/struct_test.exs
@@ -1,9 +1,13 @@
 defmodule XDR.StructTest do
+  @moduledoc """
+  Tests for the `XDR.Struct` module.
+  """
+
   use ExUnit.Case
 
   alias TestFile
   alias XDR.Struct
-  alias XDR.Error.Struct, as: StructErr
+  alias XDR.Error.Struct, as: StructError
 
   describe "Encoding Struct to binary" do
     test "when is not a list" do
@@ -69,7 +73,7 @@ defmodule XDR.StructTest do
         |> Map.from_struct()
         |> Struct.new()
 
-      assert_raise StructErr, fn -> Struct.encode_xdr!(component_keyword) end
+      assert_raise StructError, fn -> Struct.encode_xdr!(component_keyword) end
     end
   end
 
@@ -141,7 +145,7 @@ defmodule XDR.StructTest do
     test "encode_xdr! when is not a binary value" do
       component_keyword = Map.from_struct(TestFile.__struct__()) |> Map.to_list()
 
-      assert_raise StructErr, fn ->
+      assert_raise StructError, fn ->
         Struct.decode_xdr!([0, 0, 2, 0, 3, 0, 1, 0], %{components: component_keyword})
       end
     end

--- a/test/xdr/uint_test.exs
+++ b/test/xdr/uint_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.UIntTest do
+  @moduledoc """
+  Tests for the `XDR.UInt` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.UInt
-  alias XDR.Error.UInt, as: UIntErr
+  alias XDR.Error.UInt, as: UIntError
 
   describe "Encoding unsigned integer to binary" do
     test "when is not an unsigned integer value" do
@@ -52,7 +56,7 @@ defmodule XDR.UIntTest do
     test "encode_xdr! with invalid data" do
       uint = UInt.new("hello world")
 
-      assert_raise UIntErr, fn -> UInt.encode_xdr!(uint) end
+      assert_raise UIntError, fn -> UInt.encode_xdr!(uint) end
     end
   end
 
@@ -87,7 +91,7 @@ defmodule XDR.UIntTest do
     end
 
     test "decode_xdr! when is not binary value" do
-      assert_raise UIntErr, fn -> UInt.decode_xdr!([1, 2, 3, 6]) end
+      assert_raise UIntError, fn -> UInt.decode_xdr!([1, 2, 3, 6]) end
     end
   end
 end

--- a/test/xdr/union_test.exs
+++ b/test/xdr/union_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.UnionTest do
+  @moduledoc """
+  Tests for the `XDR.Union` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.Union
-  alias XDR.Error.Union, as: UnionErr
+  alias XDR.Error.Union, as: UnionError
 
   describe "new" do
     test "with Enum" do
@@ -91,7 +95,7 @@ defmodule XDR.UnionTest do
         SCP_ST_NOMINATE: XDR.Float.new(3.46)
       ]
 
-      assert_raise UnionErr, fn -> Union.encode_xdr!(%{discriminant: enum, arms: arms}) end
+      assert_raise UnionError, fn -> Union.encode_xdr!(%{discriminant: enum, arms: arms}) end
     end
 
     test "Uint example" do
@@ -126,7 +130,7 @@ defmodule XDR.UnionTest do
     end
 
     test "encode_xdr! when receives an invalid identifier" do
-      assert_raise UnionErr, fn ->
+      assert_raise UnionError, fn ->
         "SCP_ST_EXTERNALIZE"
         |> UnionSCPStatementWithTypes.new()
         |> UnionSCPStatementWithTypes.encode_xdr!()
@@ -262,7 +266,7 @@ defmodule XDR.UnionTest do
         arms: arms
       }
 
-      assert_raise UnionErr, fn -> Union.decode_xdr!([0, 0, 0, 0, 0, 0, 0, 0], enum) end
+      assert_raise UnionError, fn -> Union.decode_xdr!([0, 0, 0, 0, 0, 0, 0, 0], enum) end
     end
   end
 

--- a/test/xdr/union_test.exs
+++ b/test/xdr/union_test.exs
@@ -27,7 +27,38 @@ defmodule XDR.UnionTest do
         SCP_ST_NOMINATE: XDR.Float.new(3.46)
       ]
 
-      Union.new(enum, arms)
+      expected_union = %XDR.Union{
+        arms: [
+          SCP_ST_PREPARE: %XDR.Int{datum: 60},
+          SCP_ST_CONFIRM: %XDR.String{max_length: 4_294_967_295, string: "Confirm"},
+          SCP_ST_EXTERNALIZE: %XDR.Bool{declarations: [false: 0, true: 1], identifier: false},
+          SCP_ST_NOMINATE: %XDR.Float{float: 3.46}
+        ],
+        discriminant: %{
+          declarations: [
+            SCP_ST_PREPARE: 0,
+            SCP_ST_CONFIRM: 1,
+            SCP_ST_EXTERNALIZE: 2,
+            SCP_ST_NOMINATE: 3
+          ],
+          identifier: :SCP_ST_NOMINATE
+        },
+        value: nil
+      }
+
+      assert Union.new(enum, arms) == expected_union
+    end
+
+    test "with number map" do
+      arms = %{0 => XDR.Int, 1 => XDR.String, 2 => XDR.Bool, 3 => XDR.Float}
+
+      expected_union = %XDR.Union{
+        value: true,
+        arms: %{0 => XDR.Int, 1 => XDR.String, 2 => XDR.Bool, 3 => XDR.Float},
+        discriminant: %XDR.Int{datum: 4}
+      }
+
+      assert XDR.Int.new(4) |> Union.new(arms, true) == expected_union
     end
   end
 
@@ -98,6 +129,20 @@ defmodule XDR.UnionTest do
       assert_raise UnionError, fn -> Union.encode_xdr!(%{discriminant: enum, arms: arms}) end
     end
 
+    test "encode_xdr default arm" do
+      enum = %XDR.Enum{
+        declarations: [case_1: 1, case_2: 2, case_3: 3, case_4: 4],
+        identifier: :case_3
+      }
+
+      arms = [case_1: XDR.Int, default: XDR.Void]
+
+      {status, union_xdr} = enum |> Union.new(arms) |> Union.encode_xdr()
+
+      assert status == :ok
+      assert union_xdr == <<0, 0, 0, 3>>
+    end
+
     test "Uint example" do
       {status, result} =
         UnionNumber.new(3)
@@ -154,7 +199,7 @@ defmodule XDR.UnionTest do
       assert result == <<0, 0, 0, 0, 0, 0, 0, 60>>
     end
 
-    test "Uint example" do
+    test "encode default Uint example" do
       {status, result} = UnionNumberWithTypes.new(3, 3.46) |> UnionNumberWithTypes.encode_xdr()
 
       assert status == :ok
@@ -162,9 +207,9 @@ defmodule XDR.UnionTest do
     end
 
     test "encode_xdr! Uint example" do
-      result = UnionNumberWithTypes.new(3, 3.46) |> UnionNumberWithTypes.encode_xdr!()
+      result = UnionNumberWithTypes.new(0, 123) |> UnionNumberWithTypes.encode_xdr!()
 
-      assert result == <<0, 0, 0, 3, 64, 93, 112, 164>>
+      assert result == <<0, 0, 0, 0, 0, 0, 0, 123>>
     end
   end
 
@@ -239,6 +284,18 @@ defmodule XDR.UnionTest do
       assert result == {{:SCP_ST_PREPARE, %XDR.Int{datum: 60}}, ""}
     end
 
+    test "decode_xdr default arm" do
+      enum = %XDR.Enum{declarations: [case_1: 1, case_2: 2, case_3: 3, case_4: 4]}
+
+      arms = [case_1: XDR.Int, default: XDR.Void]
+      union_spec = Union.new(enum, arms)
+
+      {status, union} = Union.decode_xdr(<<0, 0, 0, 3>>, union_spec)
+
+      assert status == :ok
+      assert union == {{:case_3, nil}, ""}
+    end
+
     test "Uint example" do
       # It also can use the XDR.UnionNumber.decode_xdr()/1 function
       {status, result} = UnionNumber.decode_xdr(<<0, 0, 0, 3, 64, 93, 112, 164>>)
@@ -309,7 +366,7 @@ defmodule XDR.UnionTest do
       assert result == {{:SCP_ST_PREPARE, %XDR.Int{datum: 60}}, ""}
     end
 
-    test "Uint example" do
+    test "decode default Uint example" do
       {status, result} = UnionNumberWithTypes.decode_xdr(<<0, 0, 0, 3, 64, 93, 112, 164>>)
 
       assert status == :ok
@@ -317,9 +374,9 @@ defmodule XDR.UnionTest do
     end
 
     test "decode_xdr! with Uint Example" do
-      result = UnionNumberWithTypes.decode_xdr!(<<0, 0, 0, 3, 64, 93, 112, 164>>)
+      result = UnionNumberWithTypes.decode_xdr!(<<0, 0, 0, 0, 0, 0, 0, 123>>)
 
-      assert result == {{3, %XDR.Float{float: 3.4600000381469727}}, ""}
+      assert result == {{0, %XDR.Int{datum: 123}}, ""}
     end
   end
 end
@@ -419,7 +476,7 @@ defmodule UnionNumberWithTypes do
     0 => XDR.Int,
     1 => XDR.String,
     2 => XDR.Bool,
-    3 => XDR.Float
+    :default => XDR.Float
   }
 
   def new(identifier, value \\ nil) do

--- a/test/xdr/union_test.exs
+++ b/test/xdr/union_test.exs
@@ -114,6 +114,56 @@ defmodule XDR.UnionTest do
     end
   end
 
+  describe "Encoding discriminated union with types" do
+    test "when receives an invalid identifier" do
+      {status, reason} =
+        "SCP_ST_EXTERNALIZE"
+        |> UnionSCPStatementWithTypes.new()
+        |> UnionSCPStatementWithTypes.encode_xdr()
+
+      assert status == :error
+      assert reason == :not_atom
+    end
+
+    test "encode_xdr! when receives an invalid identifier" do
+      assert_raise UnionErr, fn ->
+        "SCP_ST_EXTERNALIZE"
+        |> UnionSCPStatementWithTypes.new()
+        |> UnionSCPStatementWithTypes.encode_xdr!()
+      end
+    end
+
+    test "encode_xdr Enum example" do
+      {status, result} =
+        UnionSCPStatementWithTypes.new(:SCP_ST_PREPARE, 60)
+        |> UnionSCPStatementWithTypes.encode_xdr()
+
+      assert status == :ok
+      assert result == <<0, 0, 0, 0, 0, 0, 0, 60>>
+    end
+
+    test "encode_xdr! Enum example" do
+      result =
+        UnionSCPStatementWithTypes.new(:SCP_ST_PREPARE, 60)
+        |> UnionSCPStatementWithTypes.encode_xdr!()
+
+      assert result == <<0, 0, 0, 0, 0, 0, 0, 60>>
+    end
+
+    test "Uint example" do
+      {status, result} = UnionNumberWithTypes.new(3, 3.46) |> UnionNumberWithTypes.encode_xdr()
+
+      assert status == :ok
+      assert result == <<0, 0, 0, 3, 64, 93, 112, 164>>
+    end
+
+    test "encode_xdr! Uint example" do
+      result = UnionNumberWithTypes.new(3, 3.46) |> UnionNumberWithTypes.encode_xdr!()
+
+      assert result == <<0, 0, 0, 3, 64, 93, 112, 164>>
+    end
+  end
+
   describe "Decoding Discriminated Union" do
     test "when receives an invalid identifier" do
       arms = [
@@ -215,12 +265,65 @@ defmodule XDR.UnionTest do
       assert_raise UnionErr, fn -> Union.decode_xdr!([0, 0, 0, 0, 0, 0, 0, 0], enum) end
     end
   end
+
+  describe "Decoding Discriminated Union with types" do
+    test "when receives an invalid identifier" do
+      {status, reason} = UnionSCPStatementWithTypes.decode_xdr([0, 0, 0, 0, 0, 0, 0, 0])
+
+      assert status == :error
+      assert reason == :not_binary
+    end
+
+    test "when receives an invalid declarations" do
+      {status, reason} =
+        UnionSCPStatementWithTypes.decode_xdr(<<0, 0, 0, 0, 0, 0, 0, 0>>, %{
+          discriminant: %{declarations: nil},
+          arms: []
+        })
+
+      assert status == :error
+      assert reason == :not_list
+    end
+
+    test "when receives an invalid binary" do
+      {status, reason} = UnionNumberWithTypes.decode_xdr([0, 0, 0, 3, 64, 93, 112, 164])
+
+      assert status == :error
+      assert reason == :not_binary
+    end
+
+    test "Enum example" do
+      {status, result} = UnionSCPStatementWithTypes.decode_xdr(<<0, 0, 0, 0, 0, 0, 0, 60>>)
+
+      assert status == :ok
+      assert result == {{:SCP_ST_PREPARE, %XDR.Int{datum: 60}}, ""}
+    end
+
+    test "decode_xdr! with Enum example" do
+      result = UnionSCPStatementWithTypes.decode_xdr!(<<0, 0, 0, 0, 0, 0, 0, 60>>)
+
+      assert result == {{:SCP_ST_PREPARE, %XDR.Int{datum: 60}}, ""}
+    end
+
+    test "Uint example" do
+      {status, result} = UnionNumberWithTypes.decode_xdr(<<0, 0, 0, 3, 64, 93, 112, 164>>)
+
+      assert status == :ok
+      assert result == {{3, %XDR.Float{float: 3.4600000381469727}}, ""}
+    end
+
+    test "decode_xdr! with Uint Example" do
+      result = UnionNumberWithTypes.decode_xdr!(<<0, 0, 0, 3, 64, 93, 112, 164>>)
+
+      assert result == {{3, %XDR.Float{float: 3.4600000381469727}}, ""}
+    end
+  end
 end
 
 defmodule UnionSCPStatementType do
   @behaviour XDR.Declaration
 
-  defstruct discriminant: XDR.Enum, arms: nil, struct: nil
+  defstruct discriminant: XDR.Enum, arms: nil, struct: nil, value: nil
 
   @arms [
     SCP_ST_PREPARE: XDR.Int.new(60),
@@ -255,7 +358,7 @@ end
 defmodule UnionNumber do
   @behaviour XDR.Declaration
 
-  defstruct discriminant: XDR.UInt, arms: nil, struct: nil
+  defstruct discriminant: XDR.UInt, arms: nil, struct: nil, value: nil
 
   @arms %{
     0 => XDR.Int.new(60),
@@ -305,4 +408,62 @@ defmodule SCPStatementType do
   defdelegate decode_xdr(bytes, struct), to: XDR.Enum
   @impl XDR.Declaration
   defdelegate decode_xdr!(bytes, struct), to: XDR.Enum
+end
+
+defmodule UnionNumberWithTypes do
+  @arms %{
+    0 => XDR.Int,
+    1 => XDR.String,
+    2 => XDR.Bool,
+    3 => XDR.Float
+  }
+
+  def new(identifier, value \\ nil) do
+    identifier |> XDR.UInt.new() |> XDR.Union.new(@arms, value)
+  end
+
+  @behaviour XDR.Declaration
+
+  @impl XDR.Declaration
+  def encode_xdr(union), do: XDR.Union.encode_xdr(union)
+
+  @impl XDR.Declaration
+  def encode_xdr!(union), do: XDR.Union.encode_xdr!(union)
+
+  @impl XDR.Declaration
+  def decode_xdr(bytes, union \\ new(nil))
+  def decode_xdr(bytes, union), do: XDR.Union.decode_xdr(bytes, union)
+
+  @impl XDR.Declaration
+  def decode_xdr!(bytes, union \\ new(nil))
+  def decode_xdr!(bytes, union), do: XDR.Union.decode_xdr!(bytes, union)
+end
+
+defmodule UnionSCPStatementWithTypes do
+  @arms [
+    SCP_ST_PREPARE: XDR.Int,
+    SCP_ST_CONFIRM: XDR.String,
+    SCP_ST_EXTERNALIZE: XDR.Bool,
+    SCP_ST_NOMINATE: XDR.Float
+  ]
+
+  def new(identifier, value \\ nil) do
+    identifier |> SCPStatementType.new() |> XDR.Union.new(@arms, value)
+  end
+
+  @behaviour XDR.Declaration
+
+  @impl XDR.Declaration
+  def encode_xdr(union), do: XDR.Union.encode_xdr(union)
+
+  @impl XDR.Declaration
+  def encode_xdr!(union), do: XDR.Union.encode_xdr!(union)
+
+  @impl XDR.Declaration
+  def decode_xdr(bytes, union \\ new(nil))
+  def decode_xdr(bytes, union), do: XDR.Union.decode_xdr(bytes, union)
+
+  @impl XDR.Declaration
+  def decode_xdr!(bytes, union \\ new(nil))
+  def decode_xdr!(bytes, union), do: XDR.Union.decode_xdr!(bytes, union)
 end

--- a/test/xdr/variable_array_test.exs
+++ b/test/xdr/variable_array_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.VariableArrayTest do
+  @moduledoc """
+  Tests for the `XDR.VariableArray` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.VariableArray
-  alias XDR.Error.VariableArray, as: VariableArrayErr
+  alias XDR.Error.VariableArray, as: VariableArrayError
 
   describe "Encoding Fixed Array" do
     test "when xdr is not list" do
@@ -73,7 +77,7 @@ defmodule XDR.VariableArrayTest do
     test "encode_xdr! when xdr is not list" do
       variable_array = VariableArray.new(<<0, 0, 1>>, XDR.Int, 3)
 
-      assert_raise VariableArrayErr, fn -> VariableArray.encode_xdr!(variable_array) end
+      assert_raise VariableArrayError, fn -> VariableArray.encode_xdr!(variable_array) end
     end
   end
 
@@ -186,7 +190,7 @@ defmodule XDR.VariableArrayTest do
         max_length: "3"
       }
 
-      assert_raise VariableArrayErr, fn ->
+      assert_raise VariableArrayError, fn ->
         VariableArray.decode_xdr!(<<0, 0, 1, 0>>, variable_array)
       end
     end

--- a/test/xdr/variable_opaque_test.exs
+++ b/test/xdr/variable_opaque_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.VariableOpaqueTest do
+  @moduledoc """
+  Tests for the `XDR.VariableOpaque` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.VariableOpaque
-  alias XDR.Error.VariableOpaque, as: VariableOpaqueErr
+  alias XDR.Error.VariableOpaque, as: VariableOpaqueError
 
   describe "Encoding Variable Opaque" do
     test "when xdr is not binary" do
@@ -70,7 +74,7 @@ defmodule XDR.VariableOpaqueTest do
     test "encode_xdr! when xdr is not binary" do
       variable_opaque = VariableOpaque.new([0, 0, 1], 2)
 
-      assert_raise VariableOpaqueErr, fn -> VariableOpaque.encode_xdr!(variable_opaque) end
+      assert_raise VariableOpaqueError, fn -> VariableOpaque.encode_xdr!(variable_opaque) end
     end
   end
 
@@ -134,7 +138,7 @@ defmodule XDR.VariableOpaqueTest do
     end
 
     test "decode_xdr! when xdr is not binary" do
-      assert_raise VariableOpaqueErr, fn ->
+      assert_raise VariableOpaqueError, fn ->
         VariableOpaque.decode_xdr!([0, 0, 1], %XDR.VariableOpaque{max_size: 2})
       end
     end

--- a/test/xdr/void_test.exs
+++ b/test/xdr/void_test.exs
@@ -43,7 +43,7 @@ defmodule XDR.VoidTest do
     end
   end
 
-  describe "Decoding binary to integer" do
+  describe "Decoding binary to void" do
     test "when is not binary value" do
       {status, reason} = Void.decode_xdr(5860, XDR.Void)
 
@@ -51,11 +51,11 @@ defmodule XDR.VoidTest do
       assert reason == :not_void
     end
 
-    test "with invalid binary" do
-      {status, reason} = Void.decode_xdr(<<0>>, XDR.Void)
+    test "with binary rest" do
+      {status, reason} = Void.decode_xdr(<<116, 101, 115, 116>>, XDR.Void)
 
-      assert status == :error
-      assert reason == :not_void
+      assert status == :ok
+      assert reason == {nil, <<116, 101, 115, 116>>}
     end
 
     test "when is a valid binary" do
@@ -71,12 +71,18 @@ defmodule XDR.VoidTest do
       assert reason === {nil, ""}
     end
 
+    test "decode_xdr! with rest" do
+      reason = Void.decode_xdr!(<<116, 101, 115, 116>>, XDR.Void)
+
+      assert reason === {nil, <<116, 101, 115, 116>>}
+    end
+
     test "decode_xdr! with invalid data" do
-      assert_raise VoidErr, fn -> Void.decode_xdr!(<<0>>, XDR.Void) end
+      assert_raise VoidErr, fn -> Void.decode_xdr!(12_345, XDR.Void) end
     end
 
     test "decode_xdr! with one parameter" do
-      assert_raise VoidErr, fn -> Void.decode_xdr!(<<0>>) end
+      assert_raise VoidErr, fn -> Void.decode_xdr!(nil) end
     end
   end
 end

--- a/test/xdr/void_test.exs
+++ b/test/xdr/void_test.exs
@@ -1,8 +1,12 @@
 defmodule XDR.VoidTest do
+  @moduledoc """
+  Tests for the `XDR.Void` module.
+  """
+
   use ExUnit.Case
 
   alias XDR.Void
-  alias XDR.Error.Void, as: VoidErr
+  alias XDR.Error.Void, as: VoidError
 
   describe "Encoding void to binary" do
     test "when not receive a void struct" do
@@ -13,76 +17,70 @@ defmodule XDR.VoidTest do
     end
 
     test "when receives a String" do
-      {status, reason} =
-        Void.new("hello world")
-        |> Void.encode_xdr()
+      {status, reason} = %Void{void: "hello world"} |> Void.encode_xdr()
 
       assert status == :error
       assert reason == :not_void
     end
 
     test "with valid data" do
-      {status, reason} =
-        Void.new(nil)
-        |> Void.encode_xdr()
+      {status, reason} = Void.new(nil) |> Void.encode_xdr()
 
       assert status == :ok
       assert reason == <<>>
     end
 
     test "encode_xdr! with valid data" do
-      reason =
-        Void.new(nil)
-        |> Void.encode_xdr!()
+      reason = Void.new(nil) |> Void.encode_xdr!()
 
       assert reason == <<>>
     end
 
     test "encode_xdr! with invalid data" do
-      assert_raise VoidErr, fn -> Void.encode_xdr!(nil) end
+      assert_raise VoidError, fn -> Void.encode_xdr!(nil) end
     end
   end
 
   describe "Decoding binary to void" do
     test "when is not binary value" do
-      {status, reason} = Void.decode_xdr(5860, XDR.Void)
+      {status, reason} = Void.decode_xdr(5860, Void)
 
       assert status == :error
-      assert reason == :not_void
+      assert reason == :not_binary
     end
 
     test "with binary rest" do
-      {status, reason} = Void.decode_xdr(<<116, 101, 115, 116>>, XDR.Void)
+      {status, reason} = Void.decode_xdr(<<116, 101, 115, 116>>, Void)
 
       assert status == :ok
       assert reason == {nil, <<116, 101, 115, 116>>}
     end
 
     test "when is a valid binary" do
-      {status, reason} = Void.decode_xdr(<<>>, XDR.Void)
+      {status, reason} = Void.decode_xdr(<<>>, Void)
 
       assert status == :ok
       assert reason == {nil, ""}
     end
 
     test "decode_xdr! with valid data" do
-      reason = Void.decode_xdr!(<<>>, XDR.Void)
+      reason = Void.decode_xdr!(<<>>, Void)
 
       assert reason === {nil, ""}
     end
 
     test "decode_xdr! with rest" do
-      reason = Void.decode_xdr!(<<116, 101, 115, 116>>, XDR.Void)
+      reason = Void.decode_xdr!(<<116, 101, 115, 116>>, Void)
 
       assert reason === {nil, <<116, 101, 115, 116>>}
     end
 
     test "decode_xdr! with invalid data" do
-      assert_raise VoidErr, fn -> Void.decode_xdr!(12_345, XDR.Void) end
+      assert_raise VoidError, fn -> Void.decode_xdr!(12_345, XDR.Void) end
     end
 
     test "decode_xdr! with one parameter" do
-      assert_raise VoidErr, fn -> Void.decode_xdr!(nil) end
+      assert_raise VoidError, fn -> Void.decode_xdr!(nil) end
     end
   end
 end


### PR DESCRIPTION
**Now it is possible define a default arm for the XDR Discriminated Union.**
The default arm is optional.

- Implemented default arm for a discriminated union type.
- Guide example updated
- Unit tests updated

### Reference

- https://tools.ietf.org/html/rfc4506#section-4.15