### PR TITLE
Improve XDR types' documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.1.4 (30.06.2020)
+
+* Improve README.
+* Improve documentation of all the XDR types for Hexdocs.
+* Added custom implementations of all the XDR types to examples for Hexdocs.
+* Improve functions specs for all the XDR types.
+* Improve Discriminated Union allowing add module as arm type.
+* Add Discriminated Union with `:default` arm.
+* Improve Void allowing return remaining binary after decoding.
+* Fix maximum default length set to Variable-Length Array.
+* Add some unit tests.
+* Improve the documentation and some implementations of all XDR types modules.
+
 ## 0.1.3 (22.05.2020)
 
 * Increase test coverage to 100%

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Downloads Badge](https://img.shields.io/hexpm/dt/elixir_xdr?style=for-the-badge)
 [![License badge](https://img.shields.io/hexpm/l/elixir_xdr.svg?style=for-the-badge)](https://github.com/kommitters/elixir_xdr/blob/master/LICENSE.md)
 
-Process XDR types based on the [RFC4506](https://www.ietf.org/rfc/rfc4506.txt). Extend with ease to other XDR types.
+XDR is an open data format, specified in [RFC 4506](http://tools.ietf.org/html/rfc4506.html). This library provides a way to decode and encode XDR data from Elixir. Extend with ease to other XDR types.
 
 ## Installation
 [Available in Hex](https://hex.pm/packages/elixir_xdr), Add `elixir_xdr` to your list of dependencies in `mix.exs`:
@@ -19,8 +19,8 @@ end
 ```
 
 ## Implemented types
-The following XDR types are completely implemented in this library:
 
+The following XDR types are completely implemented in this library:
 ```elixir
 # Basic types
 XDR.Int                  # Section 4.1
@@ -44,280 +44,331 @@ XDR.Union                # Section 4.15
 XDR.Optional             # Section 4.19
 ```
 
-**The following types were not implemented**
-```
-XDR.QuadFloat 	         # Section 4.8, not supported for 128-byte size.
-XDR.Const 		         # Section 4.17, can be replaced with elixir constants.
-XDR.Typedef 			 # Section 4.18, may be implemented with elixir modules. More info bellow in this guide.
+The following types were not implemented:
+```elixir
+XDR.QuadFloat            # Section 4.8, not supported for 128-byte size.
+XDR.Const                # Section 4.17, can be replaced with elixir constants.
+XDR.Typedef              # Section 4.18, may be implemented with elixir modules. More info bellow in this guide.
 ```
 
 ## Better without macros
 
-`It is an Open Source project, not a code that only I understand`
+`It is an Open Source project, not a code that only I understand.`
 
 Macros are harder to write than ordinary Elixir functions, implementing them increases the code complexity which is not good especially if you are planning to build an Open Source code easy to understand to everyone. We decided to go without macros, we want to let everyone to expand or implement their own XDR types with a clear model based on Elixir functions.
 
 ## How to implement an XDR type?
-**Behavior is the key**. When implementing a new XDR type follow this [Behavior's Declaration](https://github.com/kommitters/elixir_xdr/blob/develop/lib/xdr/declaration.ex).
+**Behaviour is the key**. When implementing a new XDR type follow this [Behaviour's Declaration](https://github.com/kommitters/elixir_xdr/blob/master/lib/xdr/declaration.ex).
 
-## Decoding output
-Encoded binaries may overflow the byte(s) size. That's why the returning value for decoding functions is set to be a tuple. Second element holds the remaining binary after decoding. **This applies to all XDR types**.
+### For Encoding
+We use the function `encode_xdr/2` or the bang version `encode_xdr!/2` to encode any XDR type to its XDR binary format.
+
+### For Decoding
+We use the function `decode_xdr/2` or the bang version `decode_xdr!/2` to decode any XDR type from an XDR binary format.
+
+In most XDR types we must pass the `type specification`, it is a struct (or map) with the attributes of the XDR type that is expected to decode.
+
 ```elixir
-iex> XDR.Int.decode_xdr!(<<0, 0, 4, 210, 5>>)
-{%XDR.Int{datum: 1234}, <<5>>}
+iex(1)> enum_spec = XDR.Enum.new([false: 0, true: 1], nil) # preferred.
+%XDR.Enum{declarations: [false: 0, true: 1], identifier: nil} 
+iex(2)> XDR.Enum.decode_xdr(<<0, 0, 0, 1>>, enum_spec)
+
+iex(1)> enum_spec = %{declarations: [false: 0, true: 1]}
+iex(2)> XDR.Enum.decode_xdr!(<<0, 0, 0, 0>>, enum_spec)
+{%XDR.Enum{declarations: [false: 0, true: 1], identifier: false}, <<>>}
 ```
 
-## Usage examples
-As mentioned before all the XDR types follow the same [Behavior's Declaration](https://github.com/kommitters/elixir_xdr/blob/develop/lib/xdr/declaration.ex)
+For all XDR types, encoded binaries may overflow the byte(s) size, that is why the returning value for decoding functions is set to be a tuple. The first element holds the XDR type decoded and the second element holds the remaining binary after decoding.
 
-### Integer
-For encoding integers use `encode_xdr/2` or use the raising version of the function `encode_xdr!/2`.
 ```elixir
-iex> XDR.Int.new(1234) |> XDR.Int.encode_xdr()
+iex(1)> {decoded_part, remaining_part} = XDR.Int.decode_xdr!(<<127, 255, 255, 255, 5>>)
+{{%XDR.Int{datum: 2147483647}, <<5>>}}
+
+# decoded_part = %XDR.Int{datum: 2147483647}
+# remaining_part = <<5>>
+```
+
+## Basic usage examples
+As mentioned before all the XDR types follow the same [Behaviour's Declaration](https://github.com/kommitters/elixir_xdr/blob/master/lib/xdr/declaration.ex)
+
+### XDR.Int - Integer
+An XDR signed integer is a 32-bit datum that encodes an integer in the range `[-2_147_483_648, 2_147_483_647]`.
+
+Encoding:
+```elixir
+iex(1)> XDR.Int.new(1234) |> XDR.Int.encode_xdr()
 {:ok, <<0, 0, 4, 210>>}
 
-iex> XDR.Int.new(1234) |> XDR.Int.encode_xdr!()
+iex(1)> XDR.Int.new(1234) |> XDR.Int.encode_xdr!()
 <<0, 0, 4, 210>>
 ```
-For decoding use `decode_xdr/2` or `decode_xdr!/2`.
+
+Decoding:
 ```elixir
-iex> XDR.Int.decode_xdr(<<0, 0, 4, 210>>)
+iex(1)> XDR.Int.decode_xdr(<<0, 0, 4, 210>>)
 {:ok, {%XDR.Int{datum: 1234}, <<>>}}
 
-iex> XDR.Int.decode_xdr!(<<0, 0, 4, 210>>)
+iex(1)> XDR.Int.decode_xdr!(<<0, 0, 4, 210>>)
 {%XDR.Int{datum: 1234}, <<>>}
 ```
 
-### Unsigned Integer
+More examples [here](https://hexdocs.pm/elixir_xdr/integer.html).
 
-Represents integer values in a range of `[0, 4294967295]`.
+### XDR.UInt - Unsigned Integer
+An XDR unsigned integer is a 32-bit datum that encodes a non-negative integer in the range `[0, 4_294_967_295]`.
 
-For encoding
+Encoding:
 ```elixir
-iex> XDR.UInt.new(564) |> XDR.UInt.encode_xdr()
+iex(1)> XDR.UInt.new(564) |> XDR.UInt.encode_xdr()
 {:ok, <<0, 0, 2, 52>>}
 
-iex> XDR.UInt.new(564) |> XDR.UInt.encode_xdr!()
+iex(1)> XDR.UInt.new(564) |> XDR.UInt.encode_xdr!()
 <<0, 0, 2, 52>>
 
 ```
 
-For decoding
+Decoding:
 ```elixir
-iex> XDR.UInt.decode_xdr(<<0, 0, 2, 52>>)
+iex(1)> XDR.UInt.decode_xdr(<<0, 0, 2, 52>>)
 {:ok, {%XDR.UInt{datum: 564}, <<>>}}
 
-iex> XDR.UInt.decode_xdr!(<<0, 0, 2, 52>>)
+iex(1)> XDR.UInt.decode_xdr!(<<0, 0, 2, 52>>)
 {%XDR.UInt{datum: 564}, <<>>}
 ```
 
-### Enumeration
+More examples [here](https://hexdocs.pm/elixir_xdr/unsigned_integer.html).
 
- Represents subsets of integers.
+### XDR.Enum - Enumeration
+Represents subsets of integers.
+The declarations of the Enumeration is a keyword list of integers (E.g. `[false: 0, true: 1]`). 
 
-**Implementation**
-
-Enums are keywords lists containing a set of **declarations (statically defined)** and a **identifier** with the key of the selected declaration. The [XDR.Bool](https://github.com/kommitters/elixir_xdr/blob/develop/lib/xdr/bool.ex) is a clear example of an Enum implementation.
-
+Encoding:
 ```elixir
-declarations = [false: 0, true: 1]
-```
-Now, you could decide the key to select
-
-For encoding
-```elixir 
-iex> XDR.Enum.new([false: 0, true: 1], :false) |> XDR.Enum.encode_xdr()
+iex(1)> XDR.Enum.new([false: 0, true: 1], :false) |> XDR.Enum.encode_xdr()
 {:ok, <<0, 0, 0, 0>>}
 
-iex> XDR.Enum.new([false: 0, true: 1], :true) |> XDR.Enum.encode_xdr!()
+iex(1)> XDR.Enum.new([false: 0, true: 1], :true) |> XDR.Enum.encode_xdr!()
 <<0, 0, 0, 1>>
 ```
 
-For decoding
+Decoding:
 ```elixir
-iex> XDR.Enum.decode_xdr(<<0, 0, 0, 1>>, %{declarations: [false: 0, true: 1]})
+iex(1)> enum_spec = XDR.Enum.new([false: 0, true: 1], nil)
+iex(2)> XDR.Enum.decode_xdr(<<0, 0, 0, 1>>, enum_spec)
 {:ok, {%XDR.Enum{declarations: [false: 0, true: 1], identifier: true}, <<>>}}
 
-iex> XDR.Enum.decode_xdr!(<<0, 0, 0, 1>>, %{declarations: [false: 0, true: 1]})
-{%XDR.Enum{declarations: [false: 0, true: 1], identifier: true}, <<>>}
+iex(1)> XDR.Enum.decode_xdr!(<<0, 0, 0, 0>>, %{declarations: [false: 0, true: 1]})
+{%XDR.Enum{declarations: [false: 0, true: 1], identifier: false}, <<>>}
 ```
 
-### Boolean
-Boolean is an Enum implementation that allows us to create boolean types
+More examples [here](https://hexdocs.pm/elixir_xdr/enumeration.html).
 
+### XDR.Bool - Boolean
+Boolean is an Enumeration implementation that allows us to create boolean types. An XDR Boolean type is a Enumeration with the keyword list `[false: 0, true: 1]` as declarations.
+
+Encoding:
 ```elixir
-iex> XDR.Bool.new(true) |> XDR.Bool.encode_xdr()
+iex(1)> XDR.Bool.new(true) |> XDR.Bool.encode_xdr()
 {:ok, <<0, 0, 0, 0>>}
 
-iex> XDR.Bool.new(true) |> XDR.Bool.encode_xdr!()
+iex(1)> XDR.Bool.new(true) |> XDR.Bool.encode_xdr!()
 <<0, 0, 0, 0>>
 ```
-For decoding the binary use `decode_xdr/2` or `decode_xdr!/2`..
+
+Decoding:
 ```elixir
-iex> XDR.Bool.decode_xdr(<<0, 0, 0, 1>>)
+iex(1)> XDR.Bool.decode_xdr(<<0, 0, 0, 1>>)
 {:ok, {%XDR.Bool{declarations: [false: 0, true: 1], identifier: true}, ""}}
 
-iex> XDR.Bool.decode_xdr!(<<0, 0, 0, 1>>)
+iex(1)> XDR.Bool.decode_xdr!(<<0, 0, 0, 1>>)
 {%XDR.Bool{declarations: [false: 0, true: 1], identifier: true}, ""}
 ```
 
-### Hyper Integer
+More examples [here](https://hexdocs.pm/elixir_xdr/boolean.html).
 
-Represents integer values in a range of `[-9223372036854775808, 9223372036854775807]`
+### XDR.HyperInt - Hyper Integer
+It is an extension of the Integer type defined above. Represents a 64-bit (8-byte) integer with values in a range of `[-9_223_372_036_854_775_808, 9_223_372_036_854_775_807]`.
 
-For encoding
-
+Encoding:
 ```elixir 
-iex> XDR.HyperInt.new(258963) |> XDR.HyperInt.encode_xdr()
-{:ok, <<0, 0, 0, 0, 0, 3, 243, 147>>}
+iex(1)> XDR.HyperInt.new(9_223_372_036_854_775_807) |> XDR.HyperInt.encode_xdr()
+{:ok, <<127, 255, 255, 255, 255, 255, 255, 255>>}
 
-iex> XDR.HyperInt.new(258963) |> XDR.HyperInt.encode_xdr!()
+iex(1)> XDR.HyperInt.new(258963) |> XDR.HyperInt.encode_xdr!()
 <<0, 0, 0, 0, 0, 3, 243, 147>>
 ```
-For encoding
+
+Decoding:
 ```elixir
-iex> XDR.HyperInt.decode_xdr(<<0, 0, 0, 0, 0, 3, 243, 147>>)
+iex(1)> XDR.HyperInt.decode_xdr(<<0, 0, 0, 0, 0, 3, 243, 147>>)
 {:ok, {%XDR.HyperInt{datum: 258963}, <<>>}}
 
-iex> XDR.HyperInt.decode_xdr!(<<0, 0, 0, 0, 0, 3, 243, 147>>)
-{%XDR.HyperInt{datum: 258963}, <<>>}
+iex(1)> XDR.HyperInt.decode_xdr!(<<127, 255, 255, 255, 255, 255, 255, 255>>)
+{%XDR.HyperInt{datum: 9223372036854775807}, <<>>}
 ```
 
-### Unsigned Hyper Integer
+More examples [here](https://hexdocs.pm/elixir_xdr/hyper_integer.html).
 
-Represents integer values in a range of `[0, 18446744073709551615]`
+### XDR.HyperUInt - Unsigned Hyper Integer
+It is an extension of the Unsigned Integer type defined above. Represents a 64-bit (8-byte) unsigned integer with values in a range of `[0, 18_446_744_073_709_551_615]`.
 
-For encoding
+Encoding:
 ```elixir 
-iex> XDR.HyperUInt.new(258963) |> XDR.HyperUInt.encode_xdr()
+iex(1)> XDR.HyperUInt.new(258963) |> XDR.HyperUInt.encode_xdr()
 {:ok, <<0, 0, 0, 0, 0, 3, 243, 147>>}
 
-iex> XDR.HyperUInt.new(258963) |> XDR.HyperUInt.encode_xdr!()
-<<0, 0, 0, 0, 0, 3, 243, 147>>
+iex(1)> XDR.HyperUInt.new(18_446_744_073_709_551_615) |> XDR.HyperUInt.encode_xdr!()
+<<255, 255, 255, 255, 255, 255, 255, 255>>
 ```
-For decoding
-```elixir
-iex> XDR.HyperUInt.decode_xdr(<<0, 0, 0, 0, 0, 3, 243, 147>>)
-{:ok, {%XDR.HyperUInt{datum: 258963}, <<>>}}
 
-iex> XDR.HyperUInt.decode_xdr!(<<0, 0, 0, 0, 0, 3, 243, 147>>)
+Decoding:
+```elixir
+iex(1)> XDR.HyperUInt.decode_xdr(<<255, 255, 255, 255, 255, 255, 255, 255>>)
+{:ok, {%XDR.HyperUInt{datum: 18446744073709551615}, <<>>}}
+
+iex(1)> XDR.HyperUInt.decode_xdr!(<<0, 0, 0, 0, 0, 3, 243, 147>>)
 {%XDR.HyperUInt{datum: 258963}, <<>>}
 ```
 
-### Floating Point
+More examples [here](https://hexdocs.pm/elixir_xdr/unsigned_hyper_integer.html).
 
-Represents single-precision float values (32 bits, 4 bytes)
+### XDR.Float - Floating Point
+Represents a single-precision float value (32 bits, 4 bytes).
 
-For encoding
+Encoding:
 ```elixir 
-iex> XDR.Float.new(3.46) |> XDR.Float.encode_xdr()
+iex(1)> XDR.Float.new(3.46) |> XDR.Float.encode_xdr()
 {:ok, <<64, 93, 112, 164>>}
 
-iex> XDR.Float.new(258963) |> XDR.Float.encode_xdr!()
-<<64, 93, 112, 164>>
+iex(1)> XDR.Float.new(-2589) |> XDR.Float.encode_xdr!()
+<<197, 33, 208, 0>> 
 ```
-For decoding
+
+Decoding:
 ```elixir
-iex> XDR.Float.decode_xdr(<<64, 93, 112, 164>>)
+iex(1)> XDR.Float.decode_xdr(<<64, 93, 112, 164>>)
 {:ok, {%XDR.Float{float: 3.4600000381469727}, <<>>}}
 
-iex> XDR.Float.decode_xdr!(<<64, 93, 112, 164>>)
-{%XDR.Float{float: 3.4600000381469727}, <<>>}
+iex(1)> XDR.Float.decode_xdr!(<<197, 33, 208, 0>>)
+{%XDR.Float{float: -2589.0}, <<>>}
 ```
 
-### Double-Floating Point
+More examples [here](https://hexdocs.pm/elixir_xdr/floating_point.html).
 
-Represents Double-precision float values (64 bits, 8 bytes)
+### XDR.DoubleFloat - Double-Floating Point
+Represents a Double-precision float value (64 bits, 8 bytes).
 
-For encoding
-```elixir 
-iex> XDR.DoubleFloat.new(3.46) |> XDR.DoubleFloat.encode_xdr()
-{:ok, <<64, 11, 174, 20, 122, 225, 71, 174>>}
-
-iex> XDR.DoubleFloat.new(258963) |> XDR.DoubleFloat.encode_xdr!()
-<<64, 11, 174, 20, 122, 225, 71, 174>>
-```
-For decoding
+Encoding:
 ```elixir
-iex> XDR.DoubleFloat.decode_xdr(<<64, 11, 174, 20, 122, 225, 71, 174>>)
-{:ok, {%XDR.DoubleFloat{float: 3.46}, <<>>}}
+iex(1)> XDR.DoubleFloat.new(0.333333333333333314829616256247390992939472198486328125) |> XDR.DoubleFloat.encode_xdr()
+{:ok, <<63, 213, 85, 85, 85, 85, 85, 85>>}
 
-iex> XDR.DoubleFloat.decode_xdr!(<<64, 11, 174, 20, 122, 225, 71, 174>>)
-{:ok, {%XDR.DoubleFloat{float: 3.46}, <<>>}}
+iex(1)> XDR.DoubleFloat.new(258963) |> XDR.DoubleFloat.encode_xdr!()
+<<65, 15, 156, 152, 0, 0, 0, 0>> 
 ```
 
-### Fixed-Length Opaque
-FixedOpaque is used for fixed-length uninterpreted data that needs to be passed among machines, in other words, let's think on a string that must match a fixed length.
-
+Decoding:
 ```elixir
-iex> ComplementBinarySize.new(<<1,2,3,4,5>>) |> ComplementBinarySize.encode_xdr()
-{:ok, <<1, 2, 3, 4, 5, 0, 0, 0>>}
+iex(1)> XDR.DoubleFloat.decode_xdr(<<65, 15, 156, 152, 0, 0, 0, 0>>)
+{:ok, {%XDR.DoubleFloat{float: 258963.0}, ""}}
+
+iex(1)> XDR.DoubleFloat.decode_xdr!(<<64, 11, 174, 20, 122, 225, 71, 174>>)
+{%XDR.DoubleFloat{float: 3.46}, <<>>}
 ```
-An example is available here: [FixedOpaque Type](https://github.com/kommitters/elixir_xdr/wiki/FixedOpaque-example).
 
-### Variable-Length Opaque
+More examples [here](https://hexdocs.pm/elixir_xdr/double_floating_point.html).
 
-Represents a sequence of n (numbered 0 through n-1) arbitrary bytes to be the number n encoded as an unsigned integer
+### XDR.FixedOpaque - Fixed-Length Opaque
+Represents a fixed-length uninterpreted data (This data is called "opaque") that needs to be passed among machines.  
 
-For encoding
+In the following examples we will use an opaque of 12-bytes length:
+
+Encoding:
+```elixir
+iex(1)> XDR.FixedOpaque.new(<<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>, 12) |> XDR.FixedOpaque.encode_xdr()
+{:ok, <<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>}
+
+iex(1)> XDR.FixedOpaque.new(<<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>, 12) |> XDR.FixedOpaque.encode_xdr!()
+<<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>
+```
+
+Decoding:
+```elixir
+iex(1)> XDR.FixedOpaque.decode_xdr(<<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>, %{length: 12})
+{:ok, {%XDR.FixedOpaque{length: 12, opaque: <<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>}, ""}} 
+
+iex(1)> opaque_spec = XDR.FixedOpaque.new(nil, 12)
+iex(2)> XDR.FixedOpaque.decode_xdr!(<<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>, opaque_spec)
+{%XDR.FixedOpaque{length: 12, opaque: <<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>}, ""}
+```
+
+More examples [here](https://hexdocs.pm/elixir_xdr/fixed_length_opaque.html).
+
+### XDR.VariableOpaque - Variable-Length Opaque
+Represents a sequence of n (numbered 0 through n-1) arbitrary bytes to be the number n encoded as an unsigned integer. If the maximum length is not specified, it is assumed to be 2<sup>32</sup> - 1, the maximum length.
+
+Encoding:
 ```elixir 
-iex> XDR.VariableOpaque.new(<<1, 2, 3, 4, 5>>) |> XDR.VariableOpaque.encode_xdr()
+iex(1)> XDR.VariableOpaque.new(<<1, 2, 3, 4, 5>>, 5) |> XDR.VariableOpaque.encode_xdr()
 {:ok, <<0, 0, 0, 5, 1, 2, 3, 4, 5, 0, 0, 0>>}
 
-iex> XDR.VariableOpaque.new(<<1, 2, 3>>, 3) |> XDR.VariableOpaque.encode_xdr!()
+iex(1)> XDR.VariableOpaque.new(<<1, 2, 3>>, 3) |> XDR.VariableOpaque.encode_xdr!()
 <<0, 0, 0, 3, 1, 2, 3, 0>>
 ```
-For decoding
+
+Decoding:
 ```elixir
-iex> XDR.VariableOpaque.decode_xdr(<<0, 0, 0, 5, 1, 2, 3, 4, 5, 0, 0, 0>>, %{max_size: 5})
+iex(1)> XDR.VariableOpaque.decode_xdr(<<0, 0, 0, 5, 1, 2, 3, 4, 5, 0, 0, 0>>, %{max_size: 5})
 {:ok, {%XDR.VariableOpaque{max_size: 5, opaque: <<1, 2, 3, 4, 5>>}, <<>>}}
 
-iex> XDR.VariableOpaque.decode_xdr!(<<0, 0, 0, 5, 1, 2, 3, 4, 5, 0, 0, 0>>, %{max_size: 5})
+iex(1)> XDR.VariableOpaque.decode_xdr!(<<0, 0, 0, 5, 1, 2, 3, 4, 5, 0, 0, 0>>, %{max_size: 5})
 {%XDR.VariableOpaque{max_size: 5, opaque: <<1, 2, 3, 4, 5>>}, <<>>}
 ```
 
-### String
-For econding strings.
-```elixir
-iex> XDR.String.new("The little prince") |> XDR.String.encode_xdr()
-{:ok,
- <<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114,
-   105, 110, 99, 101, 0, 0, 0>>}
+More examples [here](https://hexdocs.pm/elixir_xdr/variable_length_opaque.html).
 
-iex> XDR.String.new("The little prince") |> XDR.String.encode_xdr!()
-<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114,
-  105, 110, 99, 101, 0, 0, 0>>
-```
-For decoding strings.
+### XDR.String - String
+Represents a string of n (numbered 0 through n-1) ASCII bytes to be the number n encoded as an unsigned integer (as described above), and followed by the n bytes of the string. If the maximum length is not specified, it is assumed to be 2<sup>32</sup> - 1, the maximum length.
+
+Encoding:
 ```elixir
-iex> XDR.String.decode_xdr(<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114,
-  105, 110, 99, 101, 0, 0, 0>>)
+iex(1)> XDR.String.new("The little prince") |> XDR.String.encode_xdr()
+{:ok, <<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0>>}
+
+iex(1)> XDR.String.new("The little prince") |> XDR.String.encode_xdr!()
+<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0>>
+```
+
+Decoding:
+```elixir
+iex(1)> XDR.String.decode_xdr(<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0>>)
 {:ok, {%XDR.String{max_length: 4294967295, string: "The little prince"}, ""}}
 
-iex> XDR.String.decode_xdr!(<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114,
-  105, 110, 99, 101, 0, 0, 0>>)
+iex(1)> XDR.String.decode_xdr!(<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0>>)
 {%XDR.String{max_length: 4294967295, string: "The little prince"}, ""}
 ```
 
-### Fixed-Length Array
- 
-Represents a Fixed-Length array that contains the same type of elements
+More examples [here](https://hexdocs.pm/elixir_xdr/string.html).
 
-For encoding
+### XDR.FixedArray - Fixed-Length Array
+Represents a fixed-length array that contains elements with the same type.
+
+Encoding:
 ```elixir 
-iex> XDR.FixedArray.new([1,2,3], XDR.Int, 3) |> XDR.FixedArray.encode_xdr()
+iex(1)> XDR.FixedArray.new([1,2,3], XDR.Int, 3) |> XDR.FixedArray.encode_xdr()
 {:ok, <<0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3>>}
 
-iex> XDR.FixedArray.new(["The", "little", "prince"], XDR.String, 3) |> XDR.FixedArray.encode_xdr!()
+iex(1)> XDR.FixedArray.new(["The", "little", "prince"], XDR.String, 3) |> XDR.FixedArray.encode_xdr!()
 <<0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105, 116, 116, 108, 101, 0, 0,
   0, 0, 0, 6, 112, 114, 105, 110, 99, 101, 0, 0>>
 ```
-For decoding
+
+Decoding:
 ```elixir
-iex> XDR.FixedArray.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3>>, %{type: XDR.Int, length: 3})
+iex(1)> XDR.FixedArray.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3>>, %{type: XDR.Int, length: 3})
 {:ok, {[%XDR.Int{datum: 1}, %XDR.Int{datum: 2}, %XDR.Int{datum: 3}], <<>>}}
 
-iex> XDR.FixedArray.decode_xdr!(<<0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105, 116, 116, 108,
+iex(1)> XDR.FixedArray.decode_xdr!(<<0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105, 116, 116, 108,
  101, 0, 0, 0, 0, 0, 6, 112, 114, 105, 110, 99, 101, 0, 0>>, %{type: XDR.String, length: 3})
 {[
    %XDR.String{max_length: 4294967295, string: "The"},
@@ -326,26 +377,26 @@ iex> XDR.FixedArray.decode_xdr!(<<0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 
  ], <<>>}
 ```
 
-### Variable-Length Array
- 
-Represents a variable-length array which contains the same type of elements
+More examples [here](https://hexdocs.pm/elixir_xdr/fixed_length_array.html).
 
-For encoding
+### XDR.VariableArray - Variable-Length Array
+Represents a variable-length array that contains elements with the same type. If the maximum length is not specified, it is assumed to be 2<sup>32</sup> - 1, the maximum length.
+
+Encoding:
 ```elixir 
-iex> XDR.VariableArray.new([1,2,3], XDR.Int) |> XDR.VariableArray.encode_xdr()
+iex(1)> XDR.VariableArray.new([1,2,3], XDR.Int) |> XDR.VariableArray.encode_xdr()
 {:ok, <<0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3>>}
 
-iex> XDR.VariableArray.new(["The", "little", "prince"], XDR.String) |> XDR.VariableArray.encode_xdr!()
-<<0, 0, 0, 3, 0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105, 116, 116, 108,
-  101, 0, 0, 0, 0, 0, 6, 112, 114, 105, 110, 99, 101, 0, 0>>
+iex(1)> XDR.VariableArray.new(["The", "little", "prince"], XDR.String) |> XDR.VariableArray.encode_xdr!()
+<<0, 0, 0, 3, 0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105, 116, 116, 108, 101, 0, 0, 0, 0, 0, 6, 112, 114, 105, 110, 99, 101, 0, 0>>
 ```
-For decoding
+Decoding:
 ```elixir
-iex> XDR.VariableArray.decode_xdr(<<0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3>>, 
+iex(1)> XDR.VariableArray.decode_xdr(<<0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3>>, 
 ...> %{type: XDR.Int, max_length: 3})
 {:ok, {[%XDR.Int{datum: 1}, %XDR.Int{datum: 2}, %XDR.Int{datum: 3}], <<>>}}
 
-iex> XDR.VariableArray.decode_xdr!(<<0, 0, 0, 3, 0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105,
+iex(1)> XDR.VariableArray.decode_xdr!(<<0, 0, 0, 3, 0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105,
 ...> 116, 116, 108, 101, 0, 0, 0, 0, 0, 6, 112, 114, 105, 110, 99, 101, 0, 0>>, 
 ...> %{type: XDR.String, length: 3})
 {[
@@ -355,22 +406,42 @@ iex> XDR.VariableArray.decode_xdr!(<<0, 0, 0, 3, 0, 0, 0, 3, 84, 104, 101, 0, 0,
  ], <<>>}
 ```
 
-### Structure
+More examples [here](https://hexdocs.pm/elixir_xdr/variable_length_array.html).
+
+### XDR.Struct - Structure
+Represent a collection of fields, possibly of different data types, typically in fixed number and sequence.
+
+Encoding:
 ```elixir
 iex(1)> name = XDR.String.new("The little prince")
 %XDR.String{max_length: 4294967295, string: "The little prince"}
-
 iex(2)> size = XDR.Int.new(298)
 %XDR.Int{datum: 298}
+iex(3)> Struct.new([name: name, size: size]) |> Struct.encode_xdr()
+{:ok, <<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0, 0, 0, 1, 42>>}
 
-iex(3)> Book.new(name, size) |> Book.encode_xdr()
-{:ok,
- <<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114,
-   105, 110, 99, 101, 0, 0, 0, 0, 0, 1, 42>>}
+iex(1)> name = XDR.String.new("The little prince")
+%XDR.String{max_length: 4294967295, string: "The little prince"}
+iex(2)> size = XDR.Int.new(298)
+%XDR.Int{datum: 298}
+iex(3)> XDR.Struct.new([name: name, size: size]) |> XDR.Struct.encode_xdr!()
+<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0, 0, 0, 1, 42>>
 ```
-An example is available here: [Struct Type](https://github.com/kommitters/elixir_xdr/wiki/Struct-example).
 
-### Discriminated Union
+Decoding:
+```elixir
+iex(1)> struct_spec = XDR.Struct.new([name: XDR.String, size: XDR.Int])
+iex(2)> XDR.Struct.decode_xdr(<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0, 0, 0, 1, 42>>, struct_spec)
+{:ok, {%XDR.Struct{components: [name: %XDR.String{max_length: 4294967295, string: "The little prince"}, size: %XDR.Int{datum: 298}]}, ""}}
+
+iex(1)> struct_spec = XDR.Struct.new([name: XDR.String, size: XDR.Int])
+iex(2)> XDR.Struct.decode_xdr!(<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0, 0, 0, 1, 42>>, struct_spec)
+{%XDR.Struct{components: [name: %XDR.String{max_length: 4294967295, string: "The little prince"}, size: %XDR.Int{datum: 298}]}, ""}
+```
+
+More examples [here](https://hexdocs.pm/elixir_xdr/structure.html).
+
+### XDR.Union - Discriminated Union
 A discriminated union is a type composed of a discriminant followed by a type selected from a set of prearranged types according to the value of the discriminant. The component types are called `arms` of the union and are preceded by the value of the discriminant that implies their encoding or decoding. 
 
 The type of discriminant is either `XDR.Int`, `XDR.UInt`, or an `XDR.Enum` type. 
@@ -378,7 +449,6 @@ The type of discriminant is either `XDR.Int`, `XDR.UInt`, or an `XDR.Enum` type.
 The `arms` can be a keyword list or a map and the value of each arm can be either a struct or a module of any XDR type. You can define a default arm using `:default` as key (The default arm is optional).
 
 Encoding:
-
 ```elixir
 iex(1)> enum = %XDR.Enum{declarations: [case_1: 1, case_2: 2, case_3: 3], identifier: :case_1}
 iex(2)> arms = [case_1: %XDR.Int{datum: 123}, case_2: %XDR.Int{datum: 2}, case_3: XDR.Float, default: XDR.String]
@@ -387,56 +457,63 @@ iex(3)> enum |> XDR.Union.new(arms) |> XDR.Union.encode_xdr()
 ```
 
 Decoding:
-
 ```elixir
 iex(1)> enum = %XDR.Enum{declarations: [case_1: 1, case_2: 2, case_3: 3]}
 iex(2)> arms = [case_1: %XDR.Int{datum: 123}, case_2: %XDR.Int{datum: 2}, case_3: XDR.Float, default: XDR.String]
-iex(3)> union = XDR.Union.new(enum, arms) # Define the union specification to decode.
+iex(3)> union = XDR.Union.new(enum, arms)
 iex(4)> XDR.Union.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 123>>, union)
 {:ok, {{:case_1, %XDR.Int{datum: 123}}, ""}} 
 ```
 
-Some usage and implementation examples are available here: [Union Example](https://github.com/kommitters/elixir_xdr/wiki/Union-example)
+More examples [here](https://hexdocs.pm/elixir_xdr/discriminated_union.html).
 
-### Void
+### XDR.Void - Void
+Represents a 0-byte quantity.
 
-Represents the void types or nil in elixir case
-
-For encoding
+Encoding:
 ```elixir 
-iex> XDR.Void.new(nil) |> XDR.Void.encode_xdr()
+iex(1)> XDR.Void.new(nil) |> XDR.Void.encode_xdr()
 {:ok, <<>>}
 
-iex> XDR.Void.new(nil) |> XDR.Void.encode_xdr!()
+iex(1)> XDR.Void.new() |> XDR.Void.encode_xdr!()
 <<>>
 ```
-For decoding
+
+Decoding:
 ```elixir
-iex> XDR.Void.decode_xdr(<<>>)
+iex(1)> XDR.Void.decode_xdr(<<>>)
 {:ok, {nil, <<>>}}
 
-iex> XDR.Void.decode_xdr!(<<72, 101, 108, 108, 111>>)
+iex(1)> XDR.Void.decode_xdr!(<<72, 101, 108, 108, 111>>)
 {nil, <<72, 101, 108, 108, 111, 0>>}
 ```
 
-### Optional
-Think that you are filling out a form and it has optional fields such as the phone number if you do not want to fill this field you can leave it empty and the field will have a nil value, on the contrary, if you want to fill it out you can do it and it will take the indicated value
+More examples [here](https://hexdocs.pm/elixir_xdr/void.html).
 
+### XDR.Optional - Optional
+Represents one kind of union that occurs so frequently that we give it a special syntax of its own for declaring it. An optional-data could be any XDR type of data or `XDR.Void`.
+
+Encoding:
 ```elixir
-iex(1)> XDR.String.new("phone number") |> OptionalString.new() |> OptionalString.encode_xdr()
-{:ok, <<0, 0, 0, 1, 0, 0, 0, 12, 112, 104, 111, 110, 101, 32, 110, 117, 109, 98, 101, 114>>}
+iex(1)> XDR.String.new("this is an example.") |> XDR.Optional.new() |> XDR.Optional.encode_xdr()
+{:ok, <<0, 0, 0, 1, 0, 0, 0, 19, 116, 104, 105, 115, 32, 105, 115, 32, 97, 110, 32, 101, 120, 97, 109, 112, 108, 101, 46, 0>>}
 
-iex(2)> OptionalString.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 12, 112, 104, 111, 110, 101, 32, 110, 117, 109, 98, 101, 114>>)
-{:ok,
- {%XDR.Optional{type: %XDR.String{max_length: 4294967295, string: "phone number"}}, ""}}
-iex(3)> OptionalString.new(nil) |> OptionalString.encode_xdr()
-{:ok, <<0, 0, 0, 0>>}
-
-iex(4)> OptionalString.decode_xdr(<<0, 0, 0, 0>>)
-{:ok, {nil, ""}}
+iex(1)> XDR.Optional.new(nil) |> XDR.Optional.encode_xdr!()
+<<0, 0, 0, 0>>
 ```
 
-An example is available here: [Optional Type Example](https://github.com/kommitters/elixir_xdr/wiki/Optional-example)
+Decoding:
+```elixir
+iex(1)> optional_spec = XDR.Optional.new(XDR.String)
+iex(2)> XDR.Optional.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 19, 116, 104, 105, 115, 32, 105, 115, 32, 97, 110, 32, 101, 120, 97, 109, 112, 108, 101, 46, 0>>, optional_spec)
+{:ok, {%XDR.Optional{type: %XDR.String{max_length: 4294967295, string: "this is an example"}}, ""}} 
+
+iex(1)> optional_spec = XDR.Optional.new(XDR.String)
+iex(2)> XDR.Optional.decode_xdr!(<<0, 0, 0, 0>>, optional_spec)
+{nil, ""}
+```
+
+More examples [here](https://hexdocs.pm/elixir_xdr/optional_data.html).
 
 ## Contributing and Development
 See [CONTRIBUTING.md](https://github.com/kommitters/elixir_xdr/blob/master/CONTRIBUTING.md)

--- a/guides/examples/boolean.md
+++ b/guides/examples/boolean.md
@@ -1,25 +1,49 @@
-# Boolean
+# XDR.Bool - Boolean
+Boolean is an Enumeration implementation that allows us to create boolean types. An XDR Boolean type is a Enumeration with the keyword list `[false: 0, true: 1]` as declarations.
 
- It is an Enum implementation to represent the boolean values
+[Boolean - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.4)
 
 ## Usage
 
 ### Encoding
 
-```elixir 
-iex> XDR.Bool.new(false) |> XDR.Bool.encode_xdr()
+```elixir
+iex(1)> XDR.Bool.new(true) |> XDR.Bool.encode_xdr()
 {:ok, <<0, 0, 0, 0>>}
 
-iex> XDR.Bool.new(true) |> XDR.Bool.encode_xdr!()
-<<0, 0, 0, 1>>
+iex(1)> XDR.Bool.new(true) |> XDR.Bool.encode_xdr!()
+<<0, 0, 0, 0>>
 ```
 
 ### Decoding
 
 ```elixir
-iex> XDR.Bool.decode_xdr(<<0, 0, 0, 0>>)
-{:ok, {%XDR.Bool{declarations: [false: 0, true: 1], identifier: false}, <<>>}}
+iex(1)> XDR.Bool.decode_xdr(<<0, 0, 0, 1>>)
+{:ok, {%XDR.Bool{declarations: [false: 0, true: 1], identifier: true}, ""}}
 
-iex> XDR.Bool.decode_xdr!(<<0, 0, 0, 1>>)
-{%XDR.Bool{declarations: [false: 0, true: 1], identifier: true}, <<>>}
+iex(1)> XDR.Bool.decode_xdr!(<<0, 0, 0, 1>>)
+{%XDR.Bool{declarations: [false: 0, true: 1], identifier: true}, ""}
+```
+
+### Custom Boolean example
+
+```elixir
+  defmodule CustomBoolean do
+
+    @type t :: XDR.Bool.t()
+
+    defdelegate new(bool_value), to: XDR.Bool
+    defdelegate encode_xdr(bool), to: XDR.Bool
+    defdelegate encode_xdr!(bool), to: XDR.Bool
+    defdelegate decode_xdr(bytes), to: XDR.Bool
+    defdelegate decode_xdr!(bytes), to: XDR.Bool
+  end
+```
+
+```elixir
+# Encode
+CustomBoolean.new(true) |> CustomBoolean.encode_xdr()
+
+# Decode
+CustomBoolean.decode_xdr(<<0, 0, 0, 1>>)
 ```

--- a/guides/examples/discriminated_union.md
+++ b/guides/examples/discriminated_union.md
@@ -1,52 +1,13 @@
-# Discriminated Union
+# XDR.Union - Discriminated Union
+A discriminated union is a type composed of a discriminant followed by a type selected from a set of prearranged types according to the value of the discriminant. The component types are called `arms` of the union and are preceded by the value of the discriminant that implies their encoding or decoding.
 
-Represents an xdr discriminated union.
+[Discriminated Union - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.15)
 
 ## Implementation
 
 The type of discriminant is either `XDR.Int`, `XDR.UInt`, or an `XDR.Enum` type. 
 
 The `arms` can be a keyword list or a map and the value of each arm can be either a struct or a module of any XDR type. You can define a default arm using `:default` as key (The default arm is optional).
-
-### Custom Union
-
-You can define your own custom implementation:
-
-```elixir
-defmodule CustomUnion do
-
-  @arms [
-    Type_1: Type1,
-    Type_2: Type2,
-    default: Void
-  ]
-
-  @type t :: Union.t()
-
-  @spec new(value :: any(), union_code :: atom()) :: t
-  def new(value, union_code) do
-    union_code |> CustomEnum.new() |> Union.new(@arms, value)
-  end
-
-  @spec spec() :: t
-  defp spec(), do: CustomEnum.new(nil) |> Union.new(@arms)
-
-  defdelegate encode_xdr(union), to: Union
-  defdelegate encode_xdr!(union), to: Union
-  defdelegate decode_xdr(bytes, union \\ spec()), to: Union
-  defdelegate decode_xdr!(bytes, union \\ spec()), to: Union
-end
-```
-
-```elixir
-# Encode
-value_depending_on_the_type |> CustomUnion.new(:type_1) |> CustomUnion.encode_xdr()
-```
-
-```elixir
-# Decode
-CustomUnion.decode_xdr(<<1, 2, 3, 4, 5, 6, 7, 8>>)
-```
 
 ## Usage
 
@@ -134,4 +95,40 @@ iex(1)> integer = XDR.UInt.new(nil)
 iex(2)> union_spec = XDR.Union.new(integer, arms)
 iex(3)> XDR.Union.decode_xdr!(<<0, 0, 0, 2, 0, 0, 0, 7>>, union_spec)
 {{2, %XDR.Int{datum: 7}}, <<>>}
+```
+
+### Custom Union example
+
+```elixir
+defmodule CustomUnion do
+
+  @arms [
+    Type_1: Type1,
+    Type_2: Type2,
+    default: XDR.Void
+  ]
+
+  @type t :: XDR.Union.t()
+
+  @spec new(value :: any(), union_type :: atom()) :: t
+  def new(value, union_type) do
+    union_type |> CustomEnum.new() |> XDR.Union.new(@arms, value)
+  end
+
+  @spec spec() :: t
+  defp spec(), do: CustomEnum.new(nil) |> Union.new(@arms)
+
+  defdelegate encode_xdr(union), to: XDR.Union
+  defdelegate encode_xdr!(union), to: XDR.Union
+  defdelegate decode_xdr(bytes, union \\ spec()), to: XDR.Union
+  defdelegate decode_xdr!(bytes, union \\ spec()), to: XDR.Union
+end
+```
+
+```elixir
+# Encode
+value_depending_on_the_type |> CustomUnion.new(:type_1) |> CustomUnion.encode_xdr()
+
+# Decode
+CustomUnion.decode_xdr(<<1, 2, 3, 4, 5, 6, 7, 8>>)
 ```

--- a/guides/examples/double_floating_point.md
+++ b/guides/examples/double_floating_point.md
@@ -1,24 +1,49 @@
-# Double-Floating Point
+# XDR.DoubleFloat - Double-Precision Floating-Point
+Represents a Double-precision float value (64 bits, 8 bytes).
 
-Represents Double-precision float values (64 bits, 8 bytes)
+[Double-Precision Floating-Point - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.7)
+
 ## Usage
 
 ### Encoding
 
 ```elixir 
-iex> XDR.DoubleFloat.new(3.46) |> XDR.DoubleFloat.encode_xdr()
-{:ok, <<64, 11, 174, 20, 122, 225, 71, 174>>}
+iex(1)> XDR.DoubleFloat.new(0.333333333333333314829616256247390992939472198486328125) |> XDR.DoubleFloat.encode_xdr()
+{:ok, <<63, 213, 85, 85, 85, 85, 85, 85>>}
 
-iex> XDR.DoubleFloat.new(258963) |> XDR.DoubleFloat.encode_xdr!()
-<<64, 11, 174, 20, 122, 225, 71, 174>>
+iex(1)> XDR.DoubleFloat.new(258963) |> XDR.DoubleFloat.encode_xdr!()
+<<65, 15, 156, 152, 0, 0, 0, 0>> 
 ```
 
 ### Decoding
 
 ```elixir
-iex> XDR.DoubleFloat.decode_xdr(<<64, 11, 174, 20, 122, 225, 71, 174>>)
-{:ok, {%XDR.DoubleFloat{float: 3.46}, <<>>}}
+iex(1)> XDR.DoubleFloat.decode_xdr(<<65, 15, 156, 152, 0, 0, 0, 0>>)
+{:ok, {%XDR.DoubleFloat{float: 258963.0}, ""}}
 
-iex> XDR.DoubleFloat.decode_xdr!(<<64, 11, 174, 20, 122, 225, 71, 174>>)
-{:ok, {%XDR.DoubleFloat{float: 3.46}, <<>>}}
+iex(1)> XDR.DoubleFloat.decode_xdr!(<<64, 11, 174, 20, 122, 225, 71, 174>>)
+{%XDR.DoubleFloat{float: 3.46}, <<>>}
+```
+
+### Custom Double-Precision Floating-Point example
+
+```elixir
+  defmodule CustomDoubleFloat do
+
+    @type t :: XDR.DoubleFloat.t()
+
+    defdelegate new(num), to: XDR.DoubleFloat
+    defdelegate encode_xdr(double_float), to: XDR.DoubleFloat
+    defdelegate encode_xdr!(double_float), to: XDR.DoubleFloat
+    defdelegate decode_xdr(bytes), to: XDR.DoubleFloat
+    defdelegate decode_xdr!(bytes), to: XDR.DoubleFloat
+  end
+```
+
+```elixir
+# Encode
+CustomDoubleFloat.new(123.999) |> CustomDoubleFloat.encode_xdr()
+
+# Decode
+CustomDoubleFloat.decode_xdr!(<<64, 94, 255, 239, 157, 178, 45, 14>>)
 ```

--- a/guides/examples/enumeration.md
+++ b/guides/examples/enumeration.md
@@ -1,36 +1,58 @@
-# Enumeration
+# XDR.Enum - Enumeration
+Represents subsets of integers.
+The declarations of the Enumeration is a keyword list of integers (E.g. `[false: 0, true: 1]`). 
 
- Represents subsets of integers.
+ [Enumeration - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.3)
 
 ## Implementation
-
-To implement an Enumeration type we need to define the declarations as a keyword that contains the possible values to select in each key.
-In this case, we will define an integer value to each key, for example, in the boolean case, our declarations will be:
-
-```elixir
-[false: 0, true: 1]
-```
-Now, you could decide the key to select
-
+To implement an Enumeration type we need to define the declarations as a keyword list that contains the possible values to select in each key.
 
 ## Usage
 
 ### Encoding
 
 ```elixir 
-iex> XDR.Enum.new([false: 0, true: 1], :false) |> XDR.Enum.encode_xdr()
+iex(1)> XDR.Enum.new([false: 0, true: 1], :false) |> XDR.Enum.encode_xdr()
 {:ok, <<0, 0, 0, 0>>}
 
-iex> XDR.Enum.new([false: 0, true: 1], :true) |> XDR.Enum.encode_xdr!()
+iex(1)> XDR.Enum.new([false: 0, true: 1], :true) |> XDR.Enum.encode_xdr!()
 <<0, 0, 0, 1>>
 ```
 
 ### Decoding
 
 ```elixir
-iex> XDR.Enum.decode_xdr(<<0, 0, 0, 1>>, %{declarations: [false: 0, true: 1]})
+iex(1)> enum_spec = XDR.Enum.new([false: 0, true: 1], nil)
+iex(2)> XDR.Enum.decode_xdr(<<0, 0, 0, 1>>, enum_spec)
 {:ok, {%XDR.Enum{declarations: [false: 0, true: 1], identifier: true}, <<>>}}
 
-iex> XDR.Enum.decode_xdr!(<<0, 0, 0, 1>>, %{declarations: [false: 0, true: 1]})
-{%XDR.Enum{declarations: [false: 0, true: 1], identifier: true}, <<>>}
+iex(1)> XDR.Enum.decode_xdr!(<<0, 0, 0, 0>>, %{declarations: [false: 0, true: 1]})
+{%XDR.Enum{declarations: [false: 0, true: 1], identifier: false}, <<>>}
+```
+
+### Custom Enumeration example
+
+```elixir
+  defmodule CustomEnum do
+
+    @declarations [type_1: 1, type_2: 2, type_3: 3]
+
+    @type t :: XDR.Enum.t()
+
+    @spec new(identifier :: atom()) :: t
+    def new(identifier \\ nil), do: XDR.Enum.new(@declarations, identifier)
+
+    defdelegate encode_xdr(custom_enum), to: XDR.Enum
+    defdelegate encode_xdr!(custom_enum), to: XDR.Enum
+    defdelegate decode_xdr(bytes, custom_enum \\ new()), to: XDR.Enum
+    defdelegate decode_xdr!(bytes, custom_enum \\ new()), to: XDR.Enum
+  end
+```
+
+```elixir
+# Encode
+CustomEnum.new(:type_2) |> CustomEnum.encode_xdr()
+
+# Decode
+CustomEnum.decode_xdr!(<<0, 0, 0, 2>>)
 ```

--- a/guides/examples/fixed_length_array.md
+++ b/guides/examples/fixed_length_array.md
@@ -1,16 +1,17 @@
-# Fixed-Length Array
- 
-Represents a Fixed-Length array which contains the same type of elements
+# XDR.FixedArray - Fixed-Length Array
+Represents a fixed-length array that contains elements with the same type.
+
+[Fixed-Length Array - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.12)
 
 ## Usage
 
 ### Encoding
 
 ```elixir 
-iex> XDR.FixedArray.new([1,2,3], XDR.Int, 3) |> XDR.FixedArray.encode_xdr()
+iex(1)> XDR.FixedArray.new([1,2,3], XDR.Int, 3) |> XDR.FixedArray.encode_xdr()
 {:ok, <<0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3>>}
 
-iex> XDR.FixedArray.new(["The", "little", "prince"], XDR.String, 3) |> XDR.FixedArray.encode_xdr!()
+iex(1)> XDR.FixedArray.new(["The", "little", "prince"], XDR.String, 3) |> XDR.FixedArray.encode_xdr!()
 <<0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105, 116, 116, 108, 101, 0, 0,
   0, 0, 0, 6, 112, 114, 105, 110, 99, 101, 0, 0>>
 ```
@@ -18,14 +19,42 @@ iex> XDR.FixedArray.new(["The", "little", "prince"], XDR.String, 3) |> XDR.Fixed
 ### Decoding
 
 ```elixir
-iex> XDR.FixedArray.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3>>, %{type: XDR.Int, length: 3})
+iex(1)> XDR.FixedArray.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3>>, %{type: XDR.Int, length: 3})
 {:ok, {[%XDR.Int{datum: 1}, %XDR.Int{datum: 2}, %XDR.Int{datum: 3}], <<>>}}
 
-iex> XDR.FixedArray.decode_xdr!(<<0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105, 116, 116, 108,
+iex(1)> XDR.FixedArray.decode_xdr!(<<0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105, 116, 116, 108,
  101, 0, 0, 0, 0, 0, 6, 112, 114, 105, 110, 99, 101, 0, 0>>, %{type: XDR.String, length: 3})
 {[
    %XDR.String{max_length: 4294967295, string: "The"},
    %XDR.String{max_length: 4294967295, string: "little"},
    %XDR.String{max_length: 4294967295, string: "prince"}
  ], <<>>}
+```
+
+### Custom Fixed-Length Array example
+
+```elixir
+  defmodule CustomFixedArray do
+
+    @length 3
+
+    @type t :: XDR.FixedArray.t()
+
+    @spec new(list_items :: list(XDR.String.t())) :: t
+    def new(list_items \\ []) when is_list(list_items),
+      do: XDR.FixedArray.new(list_items, XDR.String, @length)
+
+    defdelegate encode_xdr(fixed_array), to: XDR.FixedArray
+    defdelegate encode_xdr!(fixed_array), to: XDR.FixedArray
+    defdelegate decode_xdr(bytes, fixed_array \\ new()), to: XDR.FixedArray
+    defdelegate decode_xdr!(bytes, fixed_array \\ new()), to: XDR.FixedArray
+  end
+```
+
+```elixir
+# Encode
+CustomFixedArray.new(["item 1", "item 2", "item 3"]) |> CustomFixedArray.encode_xdr()
+
+# Decode
+CustomFixedArray.decode_xdr!(<<0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105, 116, 116, 108, 101, 0, 0, 0, 0, 0, 6, 112, 114, 105, 110, 99, 101, 0, 0>>)
 ```

--- a/guides/examples/fixed_length_opaque.md
+++ b/guides/examples/fixed_length_opaque.md
@@ -1,25 +1,56 @@
-# Fixed-Length Opaque
+# XDR.FixedOpaque - Fixed-Length Opaque Data
+Represents a fixed-length uninterpreted data (This data is called "opaque") that needs to be passed among machines.  
 
-Represents fixed-length uninterpreted data that needs to be passed among machines.
+[Fixed-Length Opaque Data - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.9)
 
 ## Usage
+
+In the following examples we will use an opaque of 12-bytes length:
 
 ### Encoding
 
 ```elixir 
-iex> XDR.FixedOpaque.new(<<1, 2, 3, 4, 5>>, 5) |> XDR.FixedOpaque.encode_xdr()
-{:ok, <<1, 2, 3, 4, 5, 0, 0, 0>>}
+iex(1)> XDR.FixedOpaque.new(<<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>, 12) |> XDR.FixedOpaque.encode_xdr()
+{:ok, <<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>}
 
-iex> XDR.FixedOpaque.new(<<1, 2, 3>>, 3) |> XDR.FixedOpaque.encode_xdr!()
-<<1, 2, 3, 0>>
+iex(1)> XDR.FixedOpaque.new(<<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>, 12) |> XDR.FixedOpaque.encode_xdr!()
+<<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>
 ```
 
 ### Decoding
 
 ```elixir
-iex> XDR.FixedOpaque.decode_xdr(<<1, 2, 3, 4, 5, 0, 0, 0>>, %{length: 5})
-{:ok, {%XDR.FixedOpaque{length: 5, opaque: <<1, 2, 3, 4, 5>>}, <<>>}}
+iex(1)> XDR.FixedOpaque.decode_xdr(<<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>, %{length: 12})
+{:ok, {%XDR.FixedOpaque{length: 12, opaque: <<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>}, ""}} 
 
-iex> XDR.FixedOpaque.decode_xdr!(<<1, 2, 3, 4, 5, 0, 0, 0>>, %{length: 5})
-{%XDR.FixedOpaque{length: 5, opaque: <<1, 2, 3, 4, 5>>}, <<>>}
+iex(1)> opaque_spec = XDR.FixedOpaque.new(nil, 12)
+iex(2)> XDR.FixedOpaque.decode_xdr!(<<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>, opaque_spec)
+{%XDR.FixedOpaque{length: 12, opaque: <<72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 0>>}, ""}
+```
+
+### Custom Fixed-Length Opaque Data example
+
+```elixir
+  defmodule CustomFixedOpaque do
+
+    @length 10
+
+    @type t :: XDR.FixedOpaque.t()
+
+    @spec new(opaque :: binary()) :: XDR.FixedOpaque.t()
+    def new(opaque \\ nil), do: XDR.FixedOpaque.new(opaque, @length)
+
+    defdelegate encode_xdr(fixed_opaque), to: XDR.FixedOpaque
+    defdelegate encode_xdr!(fixed_opaque), to: XDR.FixedOpaque
+    defdelegate decode_xdr(bytes, fixed_opaque \\ new()), to: XDR.FixedOpaque
+    defdelegate decode_xdr!(bytes, fixed_opaque \\ new()), to: XDR.FixedOpaque
+  end
+```
+
+```elixir
+# Encode
+CustomFixedOpaque.new(<<1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>) |> CustomFixedOpaque.encode_xdr()
+
+# Decode
+CustomFixedOpaque.decode_xdr!(<<1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>)
 ```

--- a/guides/examples/floating_point.md
+++ b/guides/examples/floating_point.md
@@ -1,24 +1,49 @@
-# Floating Point
+# XDR.Float - Floating-Point
+Represents a single-precision float value (32 bits, 4 bytes).
 
-Represents single-precision float values (32 bits, 4 bytes)
+[Floating-Point - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.6)
+
 ## Usage
 
 ### Encoding
 
 ```elixir 
-iex> XDR.Float.new(3.46) |> XDR.Float.encode_xdr()
+iex(1)> XDR.Float.new(3.46) |> XDR.Float.encode_xdr()
 {:ok, <<64, 93, 112, 164>>}
 
-iex> XDR.Float.new(258963) |> XDR.Float.encode_xdr!()
-<<64, 93, 112, 164>>
+iex(1)> XDR.Float.new(-2589) |> XDR.Float.encode_xdr!()
+<<197, 33, 208, 0>> 
 ```
 
 ### Decoding
 
 ```elixir
-iex> XDR.Float.decode_xdr(<<64, 93, 112, 164>>)
+iex(1)> XDR.Float.decode_xdr(<<64, 93, 112, 164>>)
 {:ok, {%XDR.Float{float: 3.4600000381469727}, <<>>}}
 
-iex> XDR.Float.decode_xdr!(<<64, 93, 112, 164>>)
-{%XDR.Float{float: 3.4600000381469727}, <<>>}
+iex(1)> XDR.Float.decode_xdr!(<<197, 33, 208, 0>>)
+{%XDR.Float{float: -2589.0}, <<>>}
+```
+
+### Custom Floating-Point example
+
+```elixir
+  defmodule CustomFloat do
+
+    @type t :: XDR.Float.t()
+
+    defdelegate new(num), to: XDR.Float
+    defdelegate encode_xdr(float), to: XDR.Float
+    defdelegate encode_xdr!(float), to: XDR.Float
+    defdelegate decode_xdr(bytes), to: XDR.Float
+    defdelegate decode_xdr!(bytes), to: XDR.Float
+  end
+```
+
+```elixir
+# Encode
+CustomFloat.new(<<1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>) |> CustomFloat.encode_xdr()
+
+# Decode
+CustomFloat.decode_xdr!(<<1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>)
 ```

--- a/guides/examples/hyper_integer.md
+++ b/guides/examples/hyper_integer.md
@@ -1,25 +1,49 @@
-# Hyper Integer
+# XDR.HyperInt - Hyper Integer
+It is an extension of the Integer type defined above. Represents a 64-bit (8-byte) integer with values in a range of `[-9_223_372_036_854_775_808, 9_223_372_036_854_775_807]`.
 
-Represents integer values in the range `[-9223372036854775808, 9223372036854775807]`
+[Hyper Integer - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.5)
 
 ## Usage
 
 ### Encoding
 
 ```elixir 
-iex> XDR.HyperInt.new(258963) |> XDR.HyperInt.encode_xdr()
-{:ok, <<0, 0, 0, 0, 0, 3, 243, 147>>}
+iex(1)> XDR.HyperInt.new(9_223_372_036_854_775_807) |> XDR.HyperInt.encode_xdr()
+{:ok, <<127, 255, 255, 255, 255, 255, 255, 255>>}
 
-iex> XDR.HyperInt.new(258963) |> XDR.HyperInt.encode_xdr!()
+iex(1)> XDR.HyperInt.new(258963) |> XDR.HyperInt.encode_xdr!()
 <<0, 0, 0, 0, 0, 3, 243, 147>>
 ```
 
 ### Decoding
 
 ```elixir
-iex> XDR.HyperInt.decode_xdr(<<0, 0, 0, 0, 0, 3, 243, 147>>)
+iex(1)> XDR.HyperInt.decode_xdr(<<0, 0, 0, 0, 0, 3, 243, 147>>)
 {:ok, {%XDR.HyperInt{datum: 258963}, <<>>}}
 
-iex> XDR.HyperInt.decode_xdr!(<<0, 0, 0, 0, 0, 3, 243, 147>>)
-{%XDR.HyperInt{datum: 258963}, <<>>}
+iex(1)> XDR.HyperInt.decode_xdr!(<<127, 255, 255, 255, 255, 255, 255, 255>>)
+{%XDR.HyperInt{datum: 9223372036854775807}, <<>>}
+```
+
+### Custom Hyper Integer
+
+```elixir
+  defmodule CustomHyperInt do
+
+    @type t :: XDR.HyperInt.t()
+
+    defdelegate new(num), to: XDR.HyperInt
+    defdelegate encode_xdr(hyper_int), to: XDR.HyperInt
+    defdelegate encode_xdr!(hyper_int), to: XDR.HyperInt
+    defdelegate decode_xdr(bytes), to: XDR.HyperInt
+    defdelegate decode_xdr!(bytes), to: XDR.HyperInt
+  end
+```
+
+```elixir
+# Encode
+CustomHyperInt.new(123) |> CustomHyperInt.encode_xdr()
+
+# Decode
+CustomHyperInt.decode_xdr!(<<0, 0, 2, 52>>)
 ```

--- a/guides/examples/integer.md
+++ b/guides/examples/integer.md
@@ -1,24 +1,50 @@
-# Integer
+# XDR.Int - Integer
+An XDR signed integer is a 32-bit datum that encodes an integer in the range `[-2_147_483_648, 2_147_483_647]`.
 
- Represents integer values in the range `[-2147483648, 2147483647]`.
+[Integer - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.1)
 
 ## Usage
 
 ### Encoding
+
 ```elixir
-iex> XDR.Int.new(564) |> XDR.Int.encode_xdr()
+iex(1)> XDR.Int.new(564) |> XDR.Int.encode_xdr()
 {:ok, <<0, 0, 2, 52>>}
 
-iex> XDR.Int.new(564) |> XDR.Int.encode_xdr!()
+iex(1)> XDR.Int.new(564) |> XDR.Int.encode_xdr!()
 <<0, 0, 2, 52>>
 
 ```
 
 ### Decoding
+
 ```elixir
-iex> XDR.Int.decode_xdr(<<0, 0, 2, 52>>)
+iex(1)> XDR.Int.decode_xdr(<<0, 0, 2, 52>>)
 {:ok, {%XDR.Int{datum: 564}, <<>>}}
 
-iex> XDR.Int.decode_xdr!(<<0, 0, 2, 52>>)
+iex(1)> XDR.Int.decode_xdr!(<<0, 0, 2, 52>>)
 {%XDR.Int{datum: 564}, <<>>}
+```
+
+### Custom Integer example
+
+```elixir
+  defmodule CustomInt do
+
+    @type t :: XDR.Int.t()
+
+    defdelegate new(num), to: XDR.Int
+    defdelegate encode_xdr(int), to: XDR.Int
+    defdelegate encode_xdr!(int), to: XDR.Int
+    defdelegate decode_xdr(bytes), to: XDR.Int
+    defdelegate decode_xdr!(bytes), to: XDR.Int
+  end
+```
+
+```elixir
+# Encode
+CustomInt.new(123) |> CustomInt.encode_xdr()
+
+# Decode
+CustomInt.decode_xdr!(<<0, 0, 2, 52>>)
 ```

--- a/guides/examples/optional_data.md
+++ b/guides/examples/optional_data.md
@@ -1,29 +1,53 @@
-# Optional
+# XDR.Optional - Optional-Data
+Represents one kind of union that occurs so frequently that we give it a special syntax of its own for declaring it. An optional-data could be any XDR type of data or `XDR.Void`.
 
- Represents the values that can be nil or not
+[Optional-Data - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.19)
 
 ## Usage
 
 ### Encoding
 ```elixir 
-iex> XDR.Optional.new(nil) |> XDR.Optional.encode_xdr()
-{:ok, <<0, 0, 0, 0>>}
+iex(1)> XDR.String.new("this is an example.") |> XDR.Optional.new() |> XDR.Optional.encode_xdr()
+{:ok, <<0, 0, 0, 1, 0, 0, 0, 19, 116, 104, 105, 115, 32, 105, 115, 32, 97, 110, 32, 101, 120, 97, 109, 112, 108, 101, 46, 0>>}
 
-
-iex> XDR.Int.new(56) |> XDR.Optional.new() |> XDR.Optional.encode_xdr()
-{:ok, <<0, 0, 0, 1, 0, 0, 0, 56>>}
-
-iex> XDR.Int.new(56) |> XDR.Optional.new() |> XDR.Optional.encode_xdr!()
-<<0, 0, 0, 1, 0, 0, 0, 56>>
+iex(1)> XDR.Optional.new(nil) |> XDR.Optional.encode_xdr!()
+<<0, 0, 0, 0>>
 ```
 ### Decoding
 ```elixir 
-iex> XDR.Optional.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 56>>, %{type: XDR.Int})
-{:ok, {%XDR.Optional{type: %XDR.Int{datum: 56}}, <<>>}}
+iex(1)> optional_spec = XDR.Optional.new(XDR.String)
+iex(2)> XDR.Optional.decode_xdr(<<0, 0, 0, 1, 0, 0, 0, 19, 116, 104, 105, 115, 32, 105, 115, 32, 97, 110, 32, 101, 120, 97, 109, 112, 108, 101, 46, 0>>, optional_spec)
+{:ok, {%XDR.Optional{type: %XDR.String{max_length: 4294967295, string: "this is an example"}}, ""}} 
 
-iex> XDR.Optional.decode_xdr!(<<0, 0, 0, 1, 0, 0, 0, 56>>, %{type: XDR.Int})
-{%XDR.Optional{type: %XDR.Int{datum: 56}}, <<>>}
+iex(1)> optional_spec = XDR.Optional.new(XDR.String)
+iex(2)> XDR.Optional.decode_xdr!(<<0, 0, 0, 0>>, optional_spec)
+{nil, ""}
+```
 
-iex> XDR.Optional.decode_xdr!(<<0, 0, 0, 0>>, %{type: XDR.Int})
-{nil, <<>>}
+### Custom Optional-Data example
+
+```elixir
+  defmodule CustomOptional do
+
+    @type t :: XDR.Optional.t()
+
+    @spec new(number :: XDR.Int.t()) :: t
+    def new(number \\ nil), do: XDR.Optional.new(time_bounds)
+
+    @spec spec() :: t
+    defp spec(), do: XDR.Int |> new()
+
+    defdelegate encode_xdr(optional_number), to: XDR.Optional
+    defdelegate encode_xdr!(optional_number), to: XDR.Optional
+    defdelegate decode_xdr(bytes, optional_number \\ spec()), to: XDR.Optional
+    defdelegate decode_xdr!(bytes, optional_number \\ spec()), to: XDR.Optional
+  end
+```
+
+```elixir
+# Encode
+XDR.Int.new(123) |> CustomOptional.new() |> CustomOptional.encode_xdr()
+
+# Decode
+CustomOptional.decode_xdr!(<<0, 0, 0, 0>>)
 ```

--- a/guides/examples/string.md
+++ b/guides/examples/string.md
@@ -1,29 +1,53 @@
-# String
- 
-Represents string values with max size `4294967295`
+# XDR.String - String
+Represents a string of n (numbered 0 through n-1) ASCII bytes to be the number n encoded as an unsigned integer (as described above), and followed by the n bytes of the string. If the maximum length is not specified, it is assumed to be 2<sup>32</sup> - 1, the maximum length.
+
+[String - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.11)
 
 ## Usage
 
 ### Encoding
 
 ```elixir 
-iex> XDR.String.new("The little prince") |> XDR.String.encode_xdr()
-{:ok, <<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114,
- 105, 110, 99, 101, 0, 0, 0>>}
+iex(1)> XDR.String.new("The little prince") |> XDR.String.encode_xdr()
+{:ok, <<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0>>}
 
-iex> XDR.String.new("The little prince", 17) |> XDR.String.encode_xdr!()
-<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114,
-  105, 110, 99, 101, 0, 0, 0>>
+iex(1)> XDR.String.new("The little prince") |> XDR.String.encode_xdr!()
+<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0>>
 ```
 
 ### Decoding
 
 ```elixir
-iex> XDR.String.decode_xdr(<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116,
- 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0>>)
-{:ok, {%XDR.String{max_length: 4294967295, string: "The little prince"}, <<>>}}
+iex(1)> XDR.String.decode_xdr(<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0>>)
+{:ok, {%XDR.String{max_length: 4294967295, string: "The little prince"}, ""}}
 
-iex> XDR.String.decode_xdr!(<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116,
- 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0>>)
-{%XDR.String{max_length: 4294967295, string: "The little prince"}, <<>>}
+iex(1)> XDR.String.decode_xdr!(<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0>>)
+{%XDR.String{max_length: 4294967295, string: "The little prince"}, ""}
+```
+
+### Custom String example
+
+```elixir
+  defmodule CustomString do
+
+    @max_length 28
+
+    @type t :: XDR.String.t()
+
+    @spec new(text :: binary()) :: t
+    def new(text \\ nil), do: XDR.String.new(text, @max_length)
+
+    defdelegate encode_xdr(text), to: XDR.String
+    defdelegate encode_xdr!(text), to: XDR.String
+    defdelegate decode_xdr(bytes, string \\ new()), to: XDR.String
+    defdelegate decode_xdr!(bytes, string \\ new()), to: XDR.String
+  end
+```
+
+```elixir
+# Encode
+CustomString.new("Example") |> CustomString.encode_xdr()
+
+# Decode
+CustomString.decode_xdr!(<<0, 0, 0, 7, 69, 120, 97, 109, 112, 108, 101, 0>>)
 ```

--- a/guides/examples/structure.md
+++ b/guides/examples/structure.md
@@ -1,40 +1,66 @@
-# Structure
- 
-Represents a data set which could contain any XDR type
+# XDR.Struct - Structure
+Represent a collection of fields, possibly of different data types, typically in fixed number and sequence.
+
+[Structure - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.14)
 
 ## Usage
 
 ### Encoding
 
 ```elixir 
-iex> XDR.Struct.new([name: XDR.String.new("Jhon Doe"), age: XDR.Int.new(27)]) 
-...> |>XDR.Struct.encode_xdr()
-{:ok, <<0, 0, 0, 8, 74, 104, 111, 110, 32, 68, 111, 101, 0, 0, 0, 27>>}
+iex(1)> name = XDR.String.new("The little prince")
+%XDR.String{max_length: 4294967295, string: "The little prince"}
+iex(2)> size = XDR.Int.new(298)
+%XDR.Int{datum: 298}
+iex(3)> Struct.new([name: name, size: size]) |> Struct.encode_xdr()
+{:ok, <<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0, 0, 0, 1, 42>>}
 
-iex> XDR.Struct.new([name: XDR.String.new("Jhon Doe"), age: XDR.Int.new(27)]) 
-...> |>XDR.Struct.encode_xdr()
-<<0, 0, 0, 8, 74, 104, 111, 110, 32, 68, 111, 101, 0, 0, 0, 27>>
+iex(1)> name = XDR.String.new("The little prince")
+%XDR.String{max_length: 4294967295, string: "The little prince"}
+iex(2)> size = XDR.Int.new(298)
+%XDR.Int{datum: 298}
+iex(3)> XDR.Struct.new([name: name, size: size]) |> XDR.Struct.encode_xdr!()
+<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0, 0, 0, 1, 42>>
 ```
 
 ### Decoding
 
 ```elixir
-iex> XDR.Struct.decode_xdr(<<0, 0, 0, 8, 74, 104, 111, 110, 32, 68, 111, 101, 0, 0, 0, 27>>, 
-...> %{components: [name: XDR.String, age: XDR.Int]})
-{:ok,
- {%XDR.Struct{
-    components: [
-      name: %XDR.String{max_length: 4294967295, string: "Jhon Doe"},
-      age: %XDR.Int{datum: 27}
-    ]
-  }, <<>>}}
+iex(1)> struct_spec = XDR.Struct.new([name: XDR.String, size: XDR.Int])
+iex(2)> XDR.Struct.decode_xdr(<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0, 0, 0, 1, 42>>, struct_spec)
+{:ok, {%XDR.Struct{components: [name: %XDR.String{max_length: 4294967295, string: "The little prince"}, size: %XDR.Int{datum: 298}]}, ""}}
 
-iex> XDR.Struct.decode_xdr!(<<0, 0, 0, 8, 74, 104, 111, 110, 32, 68, 111, 101, 0, 0, 0, 27>>,
-...> %{components: [name: XDR.String, age: XDR.Int]})
-{%XDR.Struct{
-   components: [
-     name: %XDR.String{max_length: 4294967295, string: "Jhon Doe"},
-     age: %XDR.Int{datum: 27}
-   ]
- }, <<>>}
+iex(1)> struct_spec = XDR.Struct.new([name: XDR.String, size: XDR.Int])
+iex(2)> XDR.Struct.decode_xdr!(<<0, 0, 0, 17, 84, 104, 101, 32, 108, 105, 116, 116, 108, 101, 32, 112, 114, 105, 110, 99, 101, 0, 0, 0, 0, 0, 1, 42>>, struct_spec)
+{%XDR.Struct{components: [name: %XDR.String{max_length: 4294967295, string: "The little prince"}, size: %XDR.Int{datum: 298}]}, ""}
+```
+
+### Custom Structure example
+
+```elixir
+  defmodule CustomStruct do
+
+    @struct_spec [name: XDR.String, age: XDR.UInt]
+
+    @type t :: Struct.t()
+
+    @spec new(params :: keyword() | struct()) :: t
+    def new(params), do: Struct.new(params)
+
+    @spec spec() :: t
+    defp spec(), do: new(@struct_spec)
+
+    defdelegate encode_xdr(struct), to: Struct
+    defdelegate encode_xdr!(struct), to: Struct
+    defdelegate decode_xdr(bytes, struct \\ spec()), to: Struct
+    defdelegate decode_xdr!(bytes, struct \\ spec()), to: Struct
+  end
+```
+
+```elixir
+# Encode
+[name: "John Doe", age: %XDR.UInt{datum: 32}] |> CustomStruct.new() |> CustomStruct.encode_xdr()
+
+# Decode
+CustomStruct.decode_xdr!(<<0, 0, 2, 43, 1, 2, 3, 52>>)
 ```

--- a/guides/examples/unsigned_hyper_integer.md
+++ b/guides/examples/unsigned_hyper_integer.md
@@ -1,25 +1,49 @@
-# Unsigned Hyper Integer
+# XDR.HyperUInt - Unsigned Hyper Integer
+It is an extension of the Unsigned Integer type defined above. Represents a 64-bit (8-byte) unsigned integer with values in a range of `[0, 18_446_744_073_709_551_615]`.
 
-Represents integer values in the range `[0, 18446744073709551615]`
+[Unsigned Hyper Integer - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.5)
 
 ## Usage
 
 ### Encoding
 
 ```elixir 
-iex> XDR.HyperUInt.new(258963) |> XDR.HyperUInt.encode_xdr()
+iex(1)> XDR.HyperUInt.new(258963) |> XDR.HyperUInt.encode_xdr()
 {:ok, <<0, 0, 0, 0, 0, 3, 243, 147>>}
 
-iex> XDR.HyperUInt.new(258963) |> XDR.HyperUInt.encode_xdr!()
-<<0, 0, 0, 0, 0, 3, 243, 147>>
+iex(1)> XDR.HyperUInt.new(18_446_744_073_709_551_615) |> XDR.HyperUInt.encode_xdr!()
+<<255, 255, 255, 255, 255, 255, 255, 255>>
 ```
 
 ### Decoding
 
 ```elixir
-iex> XDR.HyperUInt.decode_xdr(<<0, 0, 0, 0, 0, 3, 243, 147>>)
-{:ok, {%XDR.HyperUInt{datum: 258963}, <<>>}}
+iex(1)> XDR.HyperUInt.decode_xdr(<<255, 255, 255, 255, 255, 255, 255, 255>>)
+{:ok, {%XDR.HyperUInt{datum: 18446744073709551615}, <<>>}}
 
-iex> XDR.HyperUInt.decode_xdr!(<<0, 0, 0, 0, 0, 3, 243, 147>>)
+iex(1)> XDR.HyperUInt.decode_xdr!(<<0, 0, 0, 0, 0, 3, 243, 147>>)
 {%XDR.HyperUInt{datum: 258963}, <<>>}
+```
+
+### Custom Unsigned Integer example
+
+```elixir
+  defmodule CustomHyperUInt do
+
+    @type t :: XDR.HyperHyperUInt.t()
+
+    defdelegate new(num), to: XDR.HyperHyperUInt
+    defdelegate encode_xdr(hyper_uint), to: XDR.HyperHyperUInt
+    defdelegate encode_xdr!(hyper_uint), to: XDR.HyperHyperUInt
+    defdelegate decode_xdr(bytes), to: XDR.HyperHyperUInt
+    defdelegate decode_xdr!(bytes), to: XDR.HyperHyperUInt
+  end
+```
+
+```elixir
+# Encode
+CustomHyperUInt.new(123) |> CustomHyperUInt.encode_xdr()
+
+# Decode
+CustomHyperUInt.decode_xdr!(<<0, 0, 2, 52>>)
 ```

--- a/guides/examples/unsigned_integer.md
+++ b/guides/examples/unsigned_integer.md
@@ -1,24 +1,50 @@
-# Unsigned Integer
+# XDR.UInt - Unsigned Integer
+Represents integer values in the range `[0, 4_294_967_295]`.
 
- Represents integer values in the range `[0, 4294967295]`.
+[Unsigned Integer - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.2)
 
 ## Usage
 
 ### Encoding
+
 ```elixir
-iex> XDR.UInt.new(564) |> XDR.UInt.encode_xdr()
+iex(1)> XDR.UInt.new(564) |> XDR.UInt.encode_xdr()
 {:ok, <<0, 0, 2, 52>>}
 
-iex> XDR.UInt.new(564) |> XDR.UInt.encode_xdr!()
+iex(1)> XDR.UInt.new(564) |> XDR.UInt.encode_xdr!()
 <<0, 0, 2, 52>>
 
 ```
 
 ### Decoding
+
 ```elixir
-iex> XDR.UInt.decode_xdr(<<0, 0, 2, 52>>)
+iex(1)> XDR.UInt.decode_xdr(<<0, 0, 2, 52>>)
 {:ok, {%XDR.UInt{datum: 564}, <<>>}}
 
-iex> XDR.UInt.decode_xdr!(<<0, 0, 2, 52>>)
+iex(1)> XDR.UInt.decode_xdr!(<<0, 0, 2, 52>>)
 {%XDR.UInt{datum: 564}, <<>>}
+```
+
+### Custom Unsigned Integer example
+
+```elixir
+  defmodule CustomUInt do
+
+    @type t :: XDR.UInt.t()
+
+    defdelegate new(num), to: XDR.UInt
+    defdelegate encode_xdr(uint), to: XDR.UInt
+    defdelegate encode_xdr!(uint), to: XDR.UInt
+    defdelegate decode_xdr(bytes), to: XDR.UInt
+    defdelegate decode_xdr!(bytes), to: XDR.UInt
+  end
+```
+
+```elixir
+# Encode
+CustomUInt.new(123) |> CustomUInt.encode_xdr()
+
+# Decode
+CustomUInt.decode_xdr!(<<0, 0, 2, 52>>)
 ```

--- a/guides/examples/variable_length_array.md
+++ b/guides/examples/variable_length_array.md
@@ -1,28 +1,28 @@
-# Variable-Length Array
- 
-Represents a variable-length array which contains the same type of elements
+# XDR.VariableArray - Variable-Length Array
+Represents a variable-length array that contains elements with the same type. If the maximum length is not specified, it is assumed to be 2<sup>32</sup> - 1, the maximum length.
+
+[Variable-Length Array - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.13)
 
 ## Usage
 
 ### Encoding
 
 ```elixir 
-iex> XDR.VariableArray.new([1,2,3], XDR.Int) |> XDR.VariableArray.encode_xdr()
+iex(1)> XDR.VariableArray.new([1,2,3], XDR.Int) |> XDR.VariableArray.encode_xdr()
 {:ok, <<0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3>>}
 
-iex> XDR.VariableArray.new(["The", "little", "prince"], XDR.String) |> XDR.VariableArray.encode_xdr!()
-<<0, 0, 0, 3, 0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105, 116, 116, 108,
-  101, 0, 0, 0, 0, 0, 6, 112, 114, 105, 110, 99, 101, 0, 0>>
+iex(1)> XDR.VariableArray.new(["The", "little", "prince"], XDR.String) |> XDR.VariableArray.encode_xdr!()
+<<0, 0, 0, 3, 0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105, 116, 116, 108, 101, 0, 0, 0, 0, 0, 6, 112, 114, 105, 110, 99, 101, 0, 0>>
 ```
 
 ### Decoding
 
 ```elixir
-iex> XDR.VariableArray.decode_xdr(<<0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3>>, 
+iex(1)> XDR.VariableArray.decode_xdr(<<0, 0, 0, 3, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3>>, 
 ...> %{type: XDR.Int, max_length: 3})
 {:ok, {[%XDR.Int{datum: 1}, %XDR.Int{datum: 2}, %XDR.Int{datum: 3}], <<>>}}
 
-iex> XDR.VariableArray.decode_xdr!(<<0, 0, 0, 3, 0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105,
+iex(1)> XDR.VariableArray.decode_xdr!(<<0, 0, 0, 3, 0, 0, 0, 3, 84, 104, 101, 0, 0, 0, 0, 6, 108, 105,
 ...> 116, 116, 108, 101, 0, 0, 0, 0, 0, 6, 112, 114, 105, 110, 99, 101, 0, 0>>, 
 ...> %{type: XDR.String, length: 3})
 {[
@@ -30,4 +30,32 @@ iex> XDR.VariableArray.decode_xdr!(<<0, 0, 0, 3, 0, 0, 0, 3, 84, 104, 101, 0, 0,
    %XDR.String{max_length: 4294967295, string: "little"},
    %XDR.String{max_length: 4294967295, string: "prince"}
  ], <<>>}
+```
+
+### Custom Variable-Length Array example
+
+```elixir
+  defmodule CustomVariableArray do
+
+    @max_length 100
+
+    @type t :: XDR.VariableArray.t()
+
+    @spec new(list_items :: list(XDR.String.t())) :: t
+    def new(list_items \\ []) when is_list(list_items),
+      do: XDR.VariableArray.new(list_items, XDR.String, @max_length)
+
+    defdelegate encode_xdr(variable_array), to: XDR.VariableArray
+    defdelegate encode_xdr!(variable_array), to: XDR.VariableArray
+    defdelegate decode_xdr(bytes, variable_array \\ new()), to: XDR.VariableArray
+    defdelegate decode_xdr!(bytes, variable_array \\ new()), to: XDR.VariableArray
+  end
+```
+
+```elixir
+# Encode
+CustomVariableArray.new(["item 1", "item 2"]) |> CustomVariableArray.encode_xdr()
+
+# Decode
+CustomVariableArray.decode_xdr!(<<0, 0, 2, 52>>)
 ```

--- a/guides/examples/variable_length_opaque.md
+++ b/guides/examples/variable_length_opaque.md
@@ -1,25 +1,53 @@
-# Variable-Length Opaque
+# XDR.VariableOpaque - Variable-Length Opaque
+Represents a sequence of n (numbered 0 through n-1) arbitrary bytes to be the number n encoded as an unsigned integer. If the maximum length is not specified, it is assumed to be 2<sup>32</sup> - 1, the maximum length.
 
-Represents a sequence of n (numbered 0 through n-1) arbitrary bytes to be the number n encoded as an unsigned integer
-
-## Usage
+[Variable-Length Opaque - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.10)
 
 ### Encoding
 
 ```elixir 
-iex> XDR.VariableOpaque.new(<<1, 2, 3, 4, 5>>) |> XDR.VariableOpaque.encode_xdr()
+iex(1)> XDR.VariableOpaque.new(<<1, 2, 3, 4, 5>>, 5) |> XDR.VariableOpaque.encode_xdr()
 {:ok, <<0, 0, 0, 5, 1, 2, 3, 4, 5, 0, 0, 0>>}
 
-iex> XDR.VariableOpaque.new(<<1, 2, 3>>, 3) |> XDR.VariableOpaque.encode_xdr!()
+iex(1)> XDR.VariableOpaque.new(<<1, 2, 3>>, 3) |> XDR.VariableOpaque.encode_xdr!()
 <<0, 0, 0, 3, 1, 2, 3, 0>>
 ```
 
 ### Decoding
 
 ```elixir
-iex> XDR.VariableOpaque.decode_xdr(<<0, 0, 0, 5, 1, 2, 3, 4, 5, 0, 0, 0>>, %{max_size: 5})
+iex(1)> XDR.VariableOpaque.decode_xdr(<<0, 0, 0, 5, 1, 2, 3, 4, 5, 0, 0, 0>>, %{max_size: 5})
 {:ok, {%XDR.VariableOpaque{max_size: 5, opaque: <<1, 2, 3, 4, 5>>}, <<>>}}
 
-iex> XDR.VariableOpaque.decode_xdr!(<<0, 0, 0, 5, 1, 2, 3, 4, 5, 0, 0, 0>>, %{max_size: 5})
+iex(1)> XDR.VariableOpaque.decode_xdr!(<<0, 0, 0, 5, 1, 2, 3, 4, 5, 0, 0, 0>>, %{max_size: 5})
 {%XDR.VariableOpaque{max_size: 5, opaque: <<1, 2, 3, 4, 5>>}, <<>>}
+```
+
+### Custom Variable-Length Opaque example
+
+```elixir
+  defmodule CustomVariableOpaque do
+
+    @type t :: XDR.VariableOpaque.t()
+
+    @max_size 64
+
+    @spec new(opaque :: binary()) :: t
+    def new(opaque \\ nil, max_size \\ @max_size) when max_size <= @max_size do
+      XDR.VariableOpaque.new(opaque, max_size)
+    end
+
+    defdelegate encode_xdr(variable_opaque), to: XDR.VariableOpaque
+    defdelegate encode_xdr!(variable_opaque), to: XDR.VariableOpaque
+    defdelegate decode_xdr(bytes, variable_opaque \\ new()), to: XDR.VariableOpaque
+    defdelegate decode_xdr!(bytes, variable_opaque \\ new()), to: XDR.VariableOpaque
+  end
+```
+
+```elixir
+# Encode
+CustomVariableOpaque.new(<<1, 2, 3, 4, 5, 6, 7>>) |> CustomVariableOpaque.encode_xdr()
+
+# Decode
+CustomVariableOpaque.decode_xdr!(<<1, 2, 3, 4, 5, 6, 7>>)
 ```

--- a/guides/examples/void.md
+++ b/guides/examples/void.md
@@ -1,31 +1,49 @@
-# Void
+# XDR.Void - Void
+Represents a 0-byte quantity. Voids are useful for describing operations that take no data as input or no data as output.
 
- Represents the XDR void type or nil in elixir case. Voids are useful for describing operations that take no data as input or no data as output.
+[Void - RFC 4506](https://tools.ietf.org/html/rfc4506#section-4.16)
 
 ## Usage
 
 ### Encoding
 
 ```elixir 
-iex> XDR.Void.new(nil) |> XDR.Void.encode_xdr()
+iex(1)> XDR.Void.new(nil) |> XDR.Void.encode_xdr()
 {:ok, <<>>}
 
-iex> XDR.Void.new() |> XDR.Void.encode_xdr!()
+iex(1)> XDR.Void.new() |> XDR.Void.encode_xdr!()
 <<>>
 ```
 
 ### Decoding
 
 ```elixir 
-iex> XDR.Void.decode_xdr(<<>>)
+iex(1)> XDR.Void.decode_xdr(<<>>)
 {:ok, {nil, <<>>}}
 
-iex> XDR.Void.decode_xdr!(<<>>)
-{nil, <<>>}
-
-iex> XDR.Void.decode_xdr(<<72, 101, 108, 108, 111, 0>>)
-{:ok, {nil, <<72, 101, 108, 108, 111, 0>>}}
-
-iex> XDR.Void.decode_xdr!(<<72, 101, 108, 108, 111>>)
+iex(1)> XDR.Void.decode_xdr!(<<72, 101, 108, 108, 111>>)
 {nil, <<72, 101, 108, 108, 111, 0>>}
+```
+
+### Custom Void example
+
+```elixir
+  defmodule CustomVoid do
+
+    @type t :: XDR.Void.t()
+
+    defdelegate new(), to: XDR.Void
+    defdelegate encode_xdr(void), to: XDR.Void
+    defdelegate encode_xdr!(void), to: XDR.Void
+    defdelegate decode_xdr(bytes), to: XDR.Void
+    defdelegate decode_xdr!(bytes), to: XDR.Void
+  end
+```
+
+```elixir
+# Encode
+CustomVoid.new() |> CustomVoid.encode_xdr()
+
+# Decode
+CustomVoid.decode_xdr!(<<>>)
 ```

--- a/lib/xdr/variable_array.ex
+++ b/lib/xdr/variable_array.ex
@@ -23,7 +23,7 @@ defmodule XDR.VariableArray do
   Create a new `XDR.VariableArray` structure with the `elements`, `type` and `max_length` passed.
   """
   @spec new(elements :: list() | binary(), type :: module(), max_length :: integer()) :: t
-  def new(elements, type, max_length),
+  def new(elements, type, max_length \\ 4_294_967_295),
     do: %XDR.VariableArray{elements: elements, type: type, max_length: max_length}
 
   @impl XDR.Declaration


### PR DESCRIPTION
# Improve XDR types' documentation

- Improve README
- Fix of the variable-length array maximum default length
- Improved the `guides/examples` XDR types files.